### PR TITLE
add setup.py back to enable jupyter_releaser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup()


### PR DESCRIPTION
Jupyter Releaser uses the `setup.py` to determine the version of the package when cutting a release.