### PR TITLE
CI fix for "Testing nbclassic" on macos 3.7, 3.8, 3.9, 3.10

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Test with pytest and coverage
         if: ${{ matrix.python-version != 'pypy-3.7' }}
         run: |
-          pytest -vv --cov=nbclassic --cov-report term-missing:skip-covered || pytest -vv --cov=nbclassic --cov-report term-missing:skip-covered
+          python -m pytest -vv --cov=nbclassic --cov-report term-missing:skip-covered || python -m pytest -vv --cov=nbclassic --cov-report term-missing:skip-covered
       - name: Run the tests on pypy
         if: ${{ matrix.python-version == 'pypy-3.7' }}
         run: |
-          pytest -vv || pytest -vv -lf
+          python -m pytest -vv || python -m pytest -vv -lf
       - name: Test Running Server
         if: startsWith(runner.os, 'Linux')
         run: |


### PR DESCRIPTION
Modified the github actions for running pytest commands from "pytest foo" to "python -m pytest foo". Both usages are roughly equivalent, see [this page](https://docs.pytest.org/en/6.2.x/usage.html) for more info about the difference. These tests now succeed:

- Testing nbclassic / Build for macos 3.7
- Testing nbclassic / Build for macos 3.8
- Testing nbclassic / Build for macos 3.9
- Testing nbclassic / Build for macos 3.10

Where previously they were failing (see [here](https://github.com/jupyter/nbclassic/runs/6521440908?check_suite_focus=true) for reference to the failing tests addressed by this PR).