### PR TITLE
Exclude Services tests from ```Linux JS Tests``` Job and Separate Workflow for flaky Selenium Tests

### DIFF
--- a/.github/workflows/flaky-selenium.yml
+++ b/.github/workflows/flaky-selenium.yml
@@ -13,13 +13,13 @@ jobs:
       matrix:
         os: [ubuntu, macos]
         python-version: [ '3.7', '3.8', '3.9']
-      exclude: 
-        - os: ubuntu
-          python-version: '3.7'
-        - os: ubuntu
-          python-version: '3.9'
-        - os: macos
-          python-version: '3.8'
+        exclude: 
+          - os: ubuntu
+            python-version: '3.7'
+          - os: ubuntu
+            python-version: '3.9'
+          - os: macos
+            python-version: '3.8'
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/flaky-selenium.yml
+++ b/.github/workflows/flaky-selenium.yml
@@ -1,4 +1,4 @@
-name: Selenium Tests
+name: Flaky Selenium Tests
 
 on:
   push:
@@ -10,16 +10,16 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
-       matrix:
+      matrix:
         os: [ubuntu, macos]
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
-      exclude:
+        python-version: [ '3.7', '3.8', '3.9']
+      exclude: 
         - os: ubuntu
-          python-version: '3.8'
-        - os: macos
           python-version: '3.7'
-        - os: macos
+        - os: ubuntu
           python-version: '3.9'
+        - os: macos
+          python-version: '3.8'
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         os: [ubuntu, macos]
         group: [notebook, base, services]
+        exclude:
+          - group: services
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
-       matrix:
+      matrix:
         os: [ubuntu, macos]
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
       exclude:

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -13,13 +13,13 @@ jobs:
       matrix:
         os: [ubuntu, macos]
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
-      exclude:
-        - os: ubuntu
-          python-version: '3.8'
-        - os: macos
-          python-version: '3.7'
-        - os: macos
-          python-version: '3.9'
+        exclude:
+          - os: ubuntu
+            python-version: '3.8'
+          - os: macos
+            python-version: '3.7'
+          - os: macos
+            python-version: '3.9'
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Update: 06/03/22
- Originally, this PR attempted to pin jupyter_client <7.x to fix the services (macOS) ```Linux JS Tests``` job. 
However, while pinning jupyter_client <7.x allows the macOS services tests consistently pass locally, the CI test results are not consistent. That change has been discarded.

- Currently, the services (Ubuntu and macOS) tests are being excluded and are to be further addressed in a separate issue.
 
- Lastly, creating a separate workflow for flaky selenium tests
_________________________________________________________________________________________

Using jupyter_client 7.x dependency leads to different behavior. 
The execution of the following code in a cell, results in only two of the four expected events 
```
import os
from ipykernel.connect import get_connection_file
with open(get_connection_file(), 'w') as f:
       f.write('garbage')
       os._exit(1)
```
The two events trigged: 'kernel_restarting.Kernel', 'kernel_autorestarting.Kernel'
The two events not triggered:  'kernel_killed.Session', 'kernel_dead.Kernel'
