### PR TITLE
CI fix for "Testing nbclassic" on macos / pypy

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
         exclude:
           - os: windows
-            python-version: pypy-3.7
+            python-version: pypy-3.8
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -33,11 +33,11 @@ jobs:
         run: |
           jupyter nbclassic -h
       - name: Test with pytest and coverage
-        if: ${{ matrix.python-version != 'pypy-3.7' }}
+        if: ${{ matrix.python-version != 'pypy-3.8' }}
         run: |
           python -m pytest -vv --cov=nbclassic --cov-report term-missing:skip-covered || python -m pytest -vv --cov=nbclassic --cov-report term-missing:skip-covered
       - name: Run the tests on pypy
-        if: ${{ matrix.python-version == 'pypy-3.7' }}
+        if: ${{ matrix.python-version == 'pypy-3.8' }}
         run: |
           python -m pytest -vv || python -m pytest -vv -lf
       - name: Test Running Server


### PR DESCRIPTION
This PR proposes bumping the version of pypy being tested to 3.8 (which allows our CI tests to pass), then possibly opening a new issue for revisiting the pypy testing strategy in the future. We should think about the purpose of this test:

- Users of pypy3.7 on macos will have a hard time using notebook at all, as `cryptography` (a dependency) does not provide a wheel for pypy3.7 on macos
- Wheels are already available for needed pypy3.8 dependencies so it's a simple one line change (our CI test passes with pypy3.8)
- If we bump to pypy3.8, we do not need to maintain a build toolchain (on the CI system/runners) for the cryptography library / dependencies, which involves configuring a rust build toolchain, package manager and openssl
- We don't want to debug a from-source build of cryptography with this test, we just want a reasonable expectation that notebook works with pypy, so this keeps the test focused on the right things