### PR TITLE
Prepare for 0.4.0 release

### DIFF
--- a/nbclassic/_version.py
+++ b/nbclassic/_version.py
@@ -5,7 +5,7 @@ store the current version info of nbclassic.
 import re
 
 # Version string must appear intact for tbump versioning
-__version__ = '0.3.7'
+__version__ = '0.4.0.dev0'
 
 # Build up version_info tuple for backwards compatibility
 pattern = r'(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)'

--- a/nbclassic/static/base/js/namespace.js
+++ b/nbclassic/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "0.3.7";
+    Jupyter.version = "0.4.0";
     Jupyter._target = '_blank';
 
     return Jupyter;


### PR DESCRIPTION
This PR updates the needed files (`_version.py` and `namespace.js`) to prepare the upcoming `0.4.0` release.

@blink1073 I am not sure that the proposed changes are correct. As we have pulled the static assets, it makes sense to me to bump from `0.3.7` to `0.4.0` and see if the release works as expected. I have changed `_version.py` to `0.4.0.dev0` and `namespace.js` to `0.4.0`.but not `pyproject.toml` which is still on `0.3.7`.  Should `_version.py` be on `0.3.8.dev0` instead?
