### PR TITLE
Shim to support the notebook extensions

### DIFF
--- a/nbclassic/__init__.py
+++ b/nbclassic/__init__.py
@@ -1,13 +1,26 @@
 import os
+import sys
 from ._version import __version__ 
 
 # Packagers: modify this line if you store the notebook static files elsewhere
 DEFAULT_STATIC_FILES_PATH = os.path.join(os.path.dirname(__file__), "static")
 
-# Packagers: modify the next line if you store the notebook template files
-# elsewhere
+# Notebook shim to ensure notebook extensions do not break.
+try:
+    from notebook._version import __version__ as notebook_version
+    if notebook_version < "7":
+        from .shim_notebook import shim_notebook_6
+        shim_notebook_6()
+    else:
+        from .shim_notebook import shim_notebook_7_and_above
+        shim_notebook_7_and_above()
+except:
+    # Notebook is not available on the platform.
+    # We just shim the complete notebook module.
+    import jupyter_server
+    sys.modules["notebook"] = jupyter_server
 
-# Include both notebook/ and notebook/templates/.  This makes it
+# Include both nbclassic/ and nbclassic/templates/.  This makes it
 # possible for users to override a template with a file that inherits from that
 # template.
 #

--- a/nbclassic/__init__.py
+++ b/nbclassic/__init__.py
@@ -12,9 +12,9 @@ DEFAULT_STATIC_FILES_PATH = os.path.join(os.path.dirname(__file__), "static")
 try:
     from notebook._version import __version__ as notebook_version
 except Exception as e:
-    # Notebook is not available on the platform.
+    # No notebook python package found.
+    # Shimming notebook to jupyter_server for notebook extensions backwards compatiblity.
     # We shim the complete notebook module.
-    print('No notebook python package found. Shimming notebook to jupyter_server for notebook extensions backwards compatiblity.')
     import jupyter_server
     sys.modules["notebook"] = jupyter_server
     from jupyter_server.base import handlers
@@ -27,11 +27,13 @@ if "notebook_version" in locals():
     # We shim based on the notebook version.
     if notebook_version < "7":
         from .shim_notebook import shim_notebook_6
-        print('Shimming existing notebook python package < 7 to jupyter_server for notebook extensions backwards compatiblity.')
+        # Shimming existing notebook python package < 7 to jupyter_server.
+        # For notebook extensions backwards compatiblity.
         shim_notebook_6()
     else:
         from .shim_notebook import shim_notebook_7_and_above
-        print('Shimming existing notebook python package >= 7 to jupyter_server for notebook extensions backwards compatiblity.')
+        # Shimming existing notebook python package >= 7 to jupyter_server.
+        # For notebook extensions backwards compatiblity.
         shim_notebook_7_and_above()
 
 

--- a/nbclassic/shim_notebook.py
+++ b/nbclassic/shim_notebook.py
@@ -1,0 +1,91 @@
+"""Shim the notebook module for the classic extensions.
+"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import sys
+
+def shim_notebook_6():
+    """Define in sys.module the needed notebook packages that should be fullfilled by
+    their corresponding and backwards-compatible jupyter-server packages.
+
+    TODO Can we lazy load these loading.
+    
+    Note: We could a custom module loader to achieve similar functionality. The 
+    logic thar conditional loading seems to be more complicated than simply
+    listing by hand the needed subpackages but could avoid latency on server start.
+    
+    https://docs.python.org/3/library/importlib.html#importlib.abc.Loader
+
+    These are the notebook packages we need to shim:
+
+    auth
+    base
+    bundler <- no, already available in nbclassic
+    edit <- no, already available in nbclassic
+    files
+    gateway
+    i18n <- no, already available in nbclassic
+    kernelspecs
+    nbconvert
+    notebook <- no, already available in nbclassic
+    prometheus
+    services
+    static <- no, already available in nbclassic
+    templates <- no, already available in nbclassic
+    terminal <- no, already available in nbclassic
+    tests <- no, already available in nbclassic
+    tree <- no, already available in nbclassic
+    view
+    __init__.py <- no, already available in nbclassic
+    __main__.py <- no, already available in nbclassic
+    _sysinfo.py <- no, already available in nbclassic
+    _tz.py
+    _version.py <- no, already available in nbclassic
+    config_manager.py <- no, already available in nbclassic
+    extensions.py <- no, already available in nbclassic
+    jstest.py <- no, already available in nbclassic
+    log.py
+    nbextensions.py <- no, already available in nbclassic
+    notebookapp.py <- no, already available in nbclassic
+    serverextensions.py <- no, already available in nbclassic
+    traittypes.py <- no, already available in nbclassic
+    transutils.py <- no, already available in nbclassic
+    utils.py
+
+    """
+    from jupyter_server import auth
+    sys.modules["notebook.auth"] = auth
+    from jupyter_server import base
+    sys.modules["notebook.base"] = base
+    from jupyter_server import files
+    sys.modules["notebook.files"] = files
+    from jupyter_server import gateway
+    sys.modules["notebook.gateway"] = gateway
+    from jupyter_server import kernelspecs
+    sys.modules["notebook.kernelspecs"] = kernelspecs
+    from jupyter_server import nbconvert
+    sys.modules["notebook.nbconvert"] = nbconvert
+    from jupyter_server import prometheus
+    sys.modules["notebook.prometheus"] = prometheus
+    from jupyter_server import services
+    sys.modules["notebook.services"] = services
+    from jupyter_server import view
+    sys.modules["notebook.view"] = view
+    from jupyter_server import _tz
+    sys.modules["notebook._tz"] = _tz
+    from jupyter_server import log
+    sys.modules["notebook.log"] = log
+    from jupyter_server import utils
+    sys.modules["notebook.utils"] = utils
+
+
+def shim_notebook_7_and_above():
+    """For now, notebook v7 should be shimmed for now the same way 
+    as notebook v6. This distinction could be useful for later 
+    notebook >=7 evolutions.
+
+    TODO Discuss and remove if not needed.
+    """
+    shim_notebook_6()

--- a/nbclassic/shim_notebook.py
+++ b/nbclassic/shim_notebook.py
@@ -55,30 +55,18 @@ def shim_notebook_6():
     utils.py
 
     """
-    from jupyter_server import auth
-    sys.modules["notebook.auth"] = auth
-    from jupyter_server import base
-    sys.modules["notebook.base"] = base
-    from jupyter_server import files
-    sys.modules["notebook.files"] = files
-    from jupyter_server import gateway
-    sys.modules["notebook.gateway"] = gateway
-    from jupyter_server import kernelspecs
-    sys.modules["notebook.kernelspecs"] = kernelspecs
-    from jupyter_server import nbconvert
-    sys.modules["notebook.nbconvert"] = nbconvert
-    from jupyter_server import prometheus
-    sys.modules["notebook.prometheus"] = prometheus
-    from jupyter_server import services
-    sys.modules["notebook.services"] = services
-    from jupyter_server import view
-    sys.modules["notebook.view"] = view
-    from jupyter_server import _tz
-    sys.modules["notebook._tz"] = _tz
-    from jupyter_server import log
-    sys.modules["notebook.log"] = log
-    from jupyter_server import utils
-    sys.modules["notebook.utils"] = utils
+    sys.modules["notebook.auth"] = __import__("jupyter_server.auth")
+    sys.modules["notebook.base"] = __import__("jupyter_server.base")
+    sys.modules["notebook.files"] = __import__("jupyter_server.files")
+    sys.modules["notebook.gateway"] = __import__("jupyter_server.gateway")
+    sys.modules["notebook.kernelspecs"] = __import__("jupyter_server.kernelspecs")
+    sys.modules["notebook.nbconvert"] = __import__("jupyter_server.nbconvert")
+    sys.modules["notebook.prometheus"] = __import__("jupyter_server.prometheus")
+    sys.modules["notebook.services"] = __import__("jupyter_server.services")
+    sys.modules["notebook.view"] = __import__("jupyter_server.view")
+    sys.modules["notebook._tz"] = __import__("jupyter_server._tz")
+    sys.modules["notebook.log"] = __import__("jupyter_server.log")
+    sys.modules["notebook.utils"] = __import__("jupyter_server.utils")
 
 
 def shim_notebook_7_and_above():

--- a/nbclassic/shim_notebook.py
+++ b/nbclassic/shim_notebook.py
@@ -86,10 +86,6 @@ def shim_notebook_6():
     sys.modules["notebook.base.handlers.IPythonHandler"] = base.handlers.JupyterHandler
 
 
-#    from notebook.base import handlers as notebook_handlers
-#    notebook_handlers.IPythonHandler = base.handlers.JupyterHandler
-
-
 def shim_notebook_7_and_above():
     """For now, notebook v7 should be shimmed for now the same way 
     as notebook v6. This distinction could be useful for later 

--- a/nbclassic/shim_notebook.py
+++ b/nbclassic/shim_notebook.py
@@ -6,11 +6,12 @@
 
 import sys
 
+
 def shim_notebook_6():
     """Define in sys.module the needed notebook packages that should be fullfilled by
     their corresponding and backwards-compatible jupyter-server packages.
 
-    TODO Can we lazy load these loading.
+    TODO Can we lazy load these loadings?
     
     Note: We could a custom module loader to achieve similar functionality. The 
     logic thar conditional loading seems to be more complicated than simply
@@ -55,18 +56,38 @@ def shim_notebook_6():
     utils.py
 
     """
-    sys.modules["notebook.auth"] = __import__("jupyter_server.auth")
-    sys.modules["notebook.base"] = __import__("jupyter_server.base")
-    sys.modules["notebook.files"] = __import__("jupyter_server.files")
-    sys.modules["notebook.gateway"] = __import__("jupyter_server.gateway")
-    sys.modules["notebook.kernelspecs"] = __import__("jupyter_server.kernelspecs")
-    sys.modules["notebook.nbconvert"] = __import__("jupyter_server.nbconvert")
-    sys.modules["notebook.prometheus"] = __import__("jupyter_server.prometheus")
-    sys.modules["notebook.services"] = __import__("jupyter_server.services")
-    sys.modules["notebook.view"] = __import__("jupyter_server.view")
-    sys.modules["notebook._tz"] = __import__("jupyter_server._tz")
-    sys.modules["notebook.log"] = __import__("jupyter_server.log")
-    sys.modules["notebook.utils"] = __import__("jupyter_server.utils")
+
+    from jupyter_server import auth
+    sys.modules["notebook.auth"] = auth
+    from jupyter_server import base
+    sys.modules["notebook.base"] = base
+    from jupyter_server import files
+    sys.modules["notebook.files"] = files
+    from jupyter_server import gateway
+    sys.modules["notebook.gateway"] = gateway
+    from jupyter_server import kernelspecs
+    sys.modules["notebook.kernelspecs"] = kernelspecs
+    from jupyter_server import nbconvert
+    sys.modules["notebook.nbconvert"] = nbconvert
+    from jupyter_server import prometheus
+    sys.modules["notebook.prometheus"] = prometheus
+    from jupyter_server import services
+    sys.modules["notebook.services"] = services
+    from jupyter_server import view
+    sys.modules["notebook.view"] = view
+    from jupyter_server import _tz
+    sys.modules["notebook._tz"] = _tz
+    from jupyter_server import log
+    sys.modules["notebook.log"] = log
+    from jupyter_server import utils
+    sys.modules["notebook.utils"] = utils
+
+    base.handlers.IPythonHandler = base.handlers.JupyterHandler
+    sys.modules["notebook.base.handlers.IPythonHandler"] = base.handlers.JupyterHandler
+
+
+#    from notebook.base import handlers as notebook_handlers
+#    notebook_handlers.IPythonHandler = base.handlers.JupyterHandler
 
 
 def shim_notebook_7_and_above():


### PR DESCRIPTION
This PR add a shim to ensure the classic notebook extension installed on top of nbclassic do not break while importing notebook packages being no more available in nbclassic. To achieve this backwards compatibility, the needed module/package are shimmed, based on the existence or not of specific versions of notebook (V6, >V7).

- [x] Discuss if we need to keep distinct shimming logic for notebook v6 and notebook v7.
- [x] Discuss if we need to consider a more generic module loading shim based on https://docs.python.org/3/library/importlib.html#importlib.abc.Loader