### PR TITLE
Add post-version-spec in tool.jupyer-releaser.options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ after-bump-version = "python setup.py jsversion"
 before-build-python = ["npm install -g po2json"]
 
 [tool.jupyter-releaser.options]
+post-version-spec = "dev"
 ignore-glob = ["docs/source/examples/Notebook/Working With Markdown Cells.ipynb", "docs-translations/**/README.md", "docs/source/contributing.rst", "docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb", "CHANGELOG.md", "nbclassic/static/components/**/*.*"]
 
 [tool.tbump.version]


### PR DESCRIPTION
This adds a `post-version-spec` in the `tool.jupyer-releaser.options` as said in https://github.com/jupyter/nbclassic/pull/112#issuecomment-1149176946 to better support the release process.

@blink1073 