### PR TITLE
Revert failing 0.4.0 release

### DIFF
--- a/nbclassic/_version.py
+++ b/nbclassic/_version.py
@@ -5,7 +5,7 @@ store the current version info of nbclassic.
 import re
 
 # Version string must appear intact for tbump versioning
-__version__ = '0.5.0.dev0'
+__version__ = '0.3.7'
 
 # Build up version_info tuple for backwards compatibility
 pattern = r'(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)'

--- a/nbclassic/static/base/js/namespace.js
+++ b/nbclassic/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "0.4.0";
+    Jupyter.version = "0.3.7";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ post-version-spec = "dev"
 ignore-glob = ["docs/source/examples/Notebook/Working With Markdown Cells.ipynb", "docs-translations/**/README.md", "docs/source/contributing.rst", "docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb", "CHANGELOG.md", "nbclassic/static/components/**/*.*"]
 
 [tool.tbump.version]
-current = "0.5.0.dev0"
+current = "0.3.7"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?


### PR DESCRIPTION
The 0.4.0 release has failed due to bad creds. Reverting the changes to replay the release.