### PR TITLE
Update release notes for 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 0.4.1
+## 0.4.2
 
 ([Full Changelog](https://github.com/jupyter/nbclassic/compare/v0.4.0...ab19ce1f648c99a0cf847cf9878f1828bedbb9a8))
 
@@ -25,6 +25,10 @@
 [@antonio-rojas](https://github.com/search?q=repo%3Ajupyter%2Fnbclassic+involves%3Aantonio-rojas+updated%3A2022-07-02..2022-07-06&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyter%2Fnbclassic+involves%3Aecharles+updated%3A2022-07-02..2022-07-06&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 0.4.1
+
+This release has been skipped by the release process.
 
 ## 0.4.0
 


### PR DESCRIPTION
During the minor release yesterday, The dreft chenglog has been create by https://github.com/echarles/jupyter_releaser/actions/runs/2624849537 and I have merged https://github.com/jupyter/nbclassic/pull/124

Then I have run the full release https://github.com/echarles/jupyter_releaser/runs/7220840309?check_suite_focus=true and it has failed on the check_changelog step with the error (see (*) at the end of this comment). I have not been able to nail down the root of the issue, so I have decided to skip that step and run again the full release as I had done in previous releases in eg. jupyterlab. There were no 0.4.1. created in the nbclassic repository.

At the end, while monitoring the logs, I have realized that the 0.4.2 was being pushed, and not 0.4.1... 

@blink1073 any idea what has happend

This PR update the changelog to reflect the skipped 0.4.1 version.

@Zsailer Further you comment on gitter, we could manually change the changelog on https://github.com/jupyter/nbclassic/releases/tag/v0.4.2 Is it ok to do so?

<img width="972" alt="Screenshot 2022-07-07 at 07 05 57" src="https://user-images.githubusercontent.com/226720/177696459-366c1cce-17e2-467c-9a51-73edc57cbf2a.png">


(*)

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.5/x64/bin/jupyter-releaser", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/cli.py", line 99, in invoke
    super().invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/cli.py", line 381, in check_changelog
    changelog.check_entry(
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/changelog.py", line 264, in check_entry
    raise ValueError(f"Did not find entry for {version}")
ValueError: Did not find entry for 0.4.2
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/actions/draft_release.py", line 66, in <module>
    run_action("jupyter-releaser check-changelog")
Common Setup
    raise e
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/util.py", line 80, in run
    process = tee(cmd, **kwargs)
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/tee.py", line 155, in run
    raise subprocess.CalledProcessError(
```