### PR TITLE
fix enable-on-install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,10 @@ install_requires =
 [options.data_files]
 etc/jupyter/jupyter_server_config.d =
     jupyter_server_config.d/nbclassic.json
+share/applications =
+    jupyter-nbclassic.desktop
+share/icons/hicolor/scalable/apps =
+    nbclassic.svg
 
 
 [options.extras_require]

--- a/setup.py
+++ b/setup.py
@@ -65,12 +65,6 @@ from setupbase import (
 )
 
 
-data_files = [
-    ('share/applications', ['jupyter-nbclassic.desktop']),
-    ('share/icons/hicolor/scalable/apps', ['nbclassic.svg']),
- ]
-
-
 setup_args = dict(
     name            = name,
     description     = "A web-based notebook environment for interactive computing",
@@ -87,7 +81,6 @@ for more information.
     version         = version,
     packages        = find_packages(),
     package_data    = find_package_data(),
-    data_files      = data_files,
     author          = 'Jupyter Development Team',
     author_email    = 'jupyter@googlegroups.com',
     url             = 'http://jupyter.org',


### PR DESCRIPTION
jupyter_server_config.d/nbclassic.json isn't being installed in 0.4.x because data_files was set in both setup.cfg and setup.py. 0.3.x enables on install

Setup.py takes precedence, it is not merged with setup.cfg, so the data_files in setup.cfg was ignored by #96