### PR TITLE
fix some import errors in 0.4

### DIFF
--- a/nbclassic/bundler/handlers.py
+++ b/nbclassic/bundler/handlers.py
@@ -3,12 +3,16 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ipython_genutils.importstring import import_item
+import asyncio
+import inspect
+import concurrent.futures
+
+from traitlets.utils.importstring import import_item
 from tornado import web, gen
 
 from jupyter_server.utils import url2path
-from nbclassic.base.handlers import IPythonHandler
-from nbclassic.services.config import ConfigManager
+from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.services.config import ConfigManager
 
 from . import tools
 
@@ -30,7 +34,7 @@ def maybe_future(obj):
         return f
 
 
-class BundlerHandler(IPythonHandler):
+class BundlerHandler(JupyterHandler):
     def initialize(self):
         """Make tools module available on the handler instance for compatibility
         with existing bundler API and ease of reference."""

--- a/nbclassic/bundler/tools.py
+++ b/nbclassic/bundler/tools.py
@@ -49,7 +49,7 @@ def get_reference_patterns(abs_nb_path, version):
     """
     notebook = nbformat.read(abs_nb_path, version)
     referenced_list = []
-    for cell in nbclassic.cells:
+    for cell in notebook.cells:
         references = get_cell_reference_patterns(cell)
         if references:
             referenced_list = referenced_list + references

--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, print_function
 import os
 import gettext
 import warnings
-import gettext
 
 from tornado.web import RedirectHandler
 
@@ -107,7 +106,7 @@ class NotebookApp(
     NotebookAppTraits,
 ):
 
-    name = 'notebook'
+    name = "nbclassic"
     version = __version__
     description = _i18n("""The Jupyter HTML Notebook.
 
@@ -195,14 +194,6 @@ class NotebookApp(
         self.jinja2_env.install_gettext_translations(nbui, newstyle=False)
 
     def _link_jupyter_server_extension(self, serverapp):
-        # Monkeypatch the IPython handler to pull templates from the "correct"
-        # Jinja Environment, namespaced by "notebook".
-        def get_template(self, name):
-            """Return the jinja template object for a given name"""
-            return self.settings['notebook_jinja2_env'].get_template(name)
-
-        jupyter_server.base.handlers.JupyterHandler.get_template = get_template
-
         # Monkey-patch Jupyter Server's and nbclassic's static path list to include
         # the classic notebooks static folder.
 

--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -107,7 +107,7 @@ class NotebookApp(
     NotebookAppTraits,
 ):
 
-    name = 'nbclassic'
+    name = 'notebook'
     version = __version__
     description = _i18n("""The Jupyter HTML Notebook.
 
@@ -201,7 +201,7 @@ class NotebookApp(
             """Return the jinja template object for a given name"""
             return self.settings['notebook_jinja2_env'].get_template(name)
 
-        nbclassic.base.handlers.IPythonHandler.get_template = get_template
+        jupyter_server.base.handlers.JupyterHandler.get_template = get_template
 
         # Monkey-patch Jupyter Server's and nbclassic's static path list to include
         # the classic notebooks static folder.


### PR DESCRIPTION
Fix get_template patch, avoiding import error. Question: should the patch actually be removed? I'm not sure!

I think it might have been an erroneous find/replace that changed the app name, as this has config consequences. If it's intentional, there are still some substitutions to be made, e.g. `notebook_jinja_env` must be `nbclassic_jinja_env`.

fixes #128