### PR TITLE
Get the notebook version from notebook._version

### DIFF
--- a/nbclassic/__init__.py
+++ b/nbclassic/__init__.py
@@ -10,7 +10,7 @@ DEFAULT_STATIC_FILES_PATH = os.path.join(os.path.dirname(__file__), "static")
 # Notebook shim to ensure notebook extensions backwards compatiblity.
 
 try:
-    from notebook import version_info as notebook_version_info
+    from notebook._version import version_info as notebook_version_info
 except Exception:
     notebook_version_info = None
     # No notebook python package found.


### PR DESCRIPTION
To identify if the shim must be applied, the notebook version is read from the module. This can gives issues for https://github.com/jupyter/notebook/pull/6474 which loads nbclassic in the init (both concurrent init modules).

This PR loads the version from the _version file of notebook module. It does not change any behavior.