### PR TITLE
Fix resource display when redirecting from /notebooks/*

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -272,13 +272,13 @@ class NotebookApp(
         # Default routes
         # Order matters. The first handler to match the URL will handle the request.
         handlers = []
-        # Add a redirect from /notebooks to /edit
+        # Add a redirect from /notebooks to /files
         # for opening non-ipynb files in edit mode.
         handlers.append(
             (
                 rf"/{self.file_url_prefix}/((?!.*\.ipynb($|\?)).*)",
                 RedirectHandler,
-                {"url": self.serverapp.base_url+"edit/{0}"}
+                {"url": self.serverapp.base_url+"files/{0}"}
             )
         )
 


### PR DESCRIPTION
Fixes https://github.com/jupyter/nbclassic/issues/144
Fixes https://github.com/jupyter/nbclassic/issues/146

Restore the notebook behavior when redirecting from /notebooks to display a static resource.