### PR TITLE
Adds new file custom-preload that is loaded in a different order than custom.js before the main.js script is executed

### DIFF
--- a/nbclassic/static/custom/custom-preload.js
+++ b/nbclassic/static/custom/custom-preload.js
@@ -1,0 +1,13 @@
+// leave at least 2 line with only a star on it below, or doc generation fails
+/**
+ *
+ *
+ * Same goal as custom.js, but loaded in a different order, before the main.js script is executed
+ *
+ *
+ * @module IPython
+ * @namespace IPython
+ * @class custompreloadjs
+ * @static
+ */
+

--- a/nbclassic/static/edit/js/main.js
+++ b/nbclassic/static/edit/js/main.js
@@ -15,6 +15,7 @@ requirejs([
     'edit/js/notificationarea',
     'bidi/bidi',
     'auth/js/loginwidget', 
+    'custom-preload'
 ], function(
     $,
     contents_service,

--- a/nbclassic/static/notebook/js/main.js
+++ b/nbclassic/static/notebook/js/main.js
@@ -53,7 +53,8 @@ requirejs([
     'notebook/js/searchandreplace',
     'notebook/js/clipboard',
     'bidi/bidi',
-    'notebook/js/celltoolbarpresets/tags'
+    'notebook/js/celltoolbarpresets/tags',
+    'custom-preload'
 ], function(
     $,
     contents_service,

--- a/nbclassic/static/terminal/js/main.js
+++ b/nbclassic/static/terminal/js/main.js
@@ -8,6 +8,7 @@ requirejs([
     'auth/js/loginwidget',
     'services/config',
     'terminal/js/terminado',
+    'custom-preload'
 ], function(
     $,
     utils,

--- a/nbclassic/static/tree/js/main.js
+++ b/nbclassic/static/tree/js/main.js
@@ -38,6 +38,7 @@ requirejs([
     'tree/js/shutdownbutton',
     'auth/js/loginwidget',
     'bidi/bidi',
+    'custom-preload'
 ], function(
     $,
     contents_service,

--- a/nbclassic/templates/page.html
+++ b/nbclassic/templates/page.html
@@ -30,6 +30,7 @@
           paths: {
             'auth/js/main': 'auth/js/main.min',
             custom : '{{ base_url }}custom',
+            'custom-preload' : '{{ base_url }}custom-preload',
             nbextensions : '{{ base_url }}nbextensions',
             kernelspecs : '{{ base_url }}kernelspecs',
             underscore : 'components/underscore/underscore-min',
@@ -99,6 +100,18 @@
           }
       })
 
+      // error-catching custom-preload.js shim.
+      define("custom-preload", function (require, exports, module) {
+          try {
+              var custom = require('custom/custom-preload');
+              console.debug('loaded custom-preload.js');
+              return custom;
+          } catch (e) {
+              console.error("error loading custom-preload.js", e);
+              return {};
+          }
+      })
+      
     document.nbjs_translations = {{ nbjs_translations|safe }};
     document.documentElement.lang = navigator.language.toLowerCase();
     </script>

--- a/tools/build-main.js
+++ b/tools/build-main.js
@@ -28,7 +28,9 @@ var rjs_config = {
     "xtermjs-fit": 'components/xterm.js-fit/index',
     "jquery-typeahead": 'components/jquery-typeahead/dist/jquery.typeahead.min',
     contents: 'empty:',
-    custom: 'empty:',
+    custom: 'empty:',   
+    'custom-preload': 'empty:',
+
   },
   map: { // for backward compatibility
     "*": {
@@ -60,6 +62,7 @@ var rjs_config = {
 
   exclude: [
     "custom/custom",
+    "custom/custom-preload",
   ]
 };
 


### PR DESCRIPTION
Adds new file custom-preload that is loaded in a different order than custom.js before the main.js script is executed.

Relying on the existing file custom.js has some limitation because it gets loaded after the main.js script is executed. That makes it hard to extend some behaviors like injecting security headers:

example:

```
      $.ajaxSetup({
        beforeSend: function (xhr) {
          xhr.setRequestHeader(
            "Authorization",
            `Bearer ${connectionDetails.password}`
          );
        },
      });
```

Here is a demo video demonstrating the new behavior:


https://user-images.githubusercontent.com/1140720/194337949-669faf59-e9f7-4888-9cc9-9be5317bf755.mp4
