### PR TITLE
fix: display the correct about box if jupyter notebook command is used

### DIFF
--- a/nbclassic/static/base/js/namespace.js
+++ b/nbclassic/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "0.4.4";
+    Jupyter.version = "0.5.0.dev0";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/nbclassic/static/notebook/js/about.js
+++ b/nbclassic/static/notebook/js/about.js
@@ -9,17 +9,31 @@ requirejs([
 ], function ($, dialog, i18n, _, IPython) {
     'use strict';
     $('#notebook_about').click(function () {
+        // The baseUrlPrefix is only injected in the document by nbclassic.
+        const is_nbclassic = document.baseUrlPrefix !== undefined;
         // use underscore template to auto html escape
         if (sys_info) {
-          var text = i18n.msg._('You are using Jupyter NbClassic.');
-          text = text + '<br/><br/>';
-          text = text + i18n.msg._('The version of the Jupyter server is: ');
-          text = text + _.template('<b><%- version %></b>')({ version: sys_info.jupyter_server_version });
-          if (sys_info.commit_hash) {
-              text = text + _.template('-<%- hash %>')({ hash: sys_info.commit_hash });
+          var text = '';
+          if (is_nbclassic) {
+            text = text + i18n.msg._('You are using Jupyter NbClassic.');
+            text = text + '<br/><br/>';
+            text = text + i18n.msg._('The version of the Jupyter server is: ');
+            text = text + _.template('<b><%- version %></b>')({ version: sys_info.jupyter_server_version });
+            if (sys_info.commit_hash) {
+                text = text + _.template('-<%- hash %>')({ hash: sys_info.commit_hash });
+            }
+            text = text + '<br/>';
+            text = text + 'To get the version of nbclassic, run in a terminal: jupyter nbclassic --version';
           }
-          text = text + '<br/>';
-          text = text + 'To get the version of nbclassic, run in a terminal: jupyter nbclassic --version';
+          else {
+            text = text + i18n.msg._('You are using Jupyter Notebook.');
+            text = text + '<br/><br/>';
+            text = text + i18n.msg._('The version of the notebook server is: ');
+            text = text + _.template('<b><%- version %></b>')({ version: sys_info.notebook_version });
+            if (sys_info.commit_hash) {
+                text = text + _.template('-<%- hash %>')({ hash: sys_info.commit_hash });
+            }
+          }
           text = text + '<br/>';
           text = text + i18n.msg._('The server is running on this version of Python:');
           text = text + _.template('<br/><pre>Python <%- pyver %></pre>')({ 
@@ -36,11 +50,19 @@ requirejs([
           body.append($('<h4/>').text(i18n.msg._('Cannot find sys_info!')));
           body.append($('<p/>').html(text));
         }
-        dialog.modal({
-            title: i18n.msg._('About Jupyter NbClassic'),
-            body: body,
-            buttons: { 'OK': {} }
-        });
+        if (is_nbclassic) {
+            dialog.modal({
+                title: i18n.msg._('About Jupyter NbClassic'),
+                body: body,
+                buttons: { 'OK': {} }
+            });
+        } else {
+            dialog.modal({
+                title: i18n.msg._('About Jupyter Notebook'),
+                body: body,
+                buttons: { 'OK': {} }
+            });
+        }
         try {
             IPython.notebook.session.kernel.kernel_info(function (data) {
                 kinfo.html($('<pre/>').text(data.content.banner));


### PR DESCRIPTION
Follow-up of https://github.com/jupyter/nbclassic/pull/147
(+ revert to 0.5.0dev0 version).

When `jupyter nbclassic` command is used, the following About box is displayed.

<img width="716" alt="about-nbclassic" src="https://user-images.githubusercontent.com/226720/193809501-ad6dd8e8-5a02-4cc5-a7f0-8e43fdc04429.png">

When `jupyter notebook` command is used, the following About box is displayed.

<img width="710" alt="about-notebook" src="https://user-images.githubusercontent.com/226720/193809515-8dc8a9af-ed4d-4928-a8ce-baf77bc016b1.png">
