### PR TITLE
Use `var` instead of `const` to ensure js-test succeed

### DIFF
--- a/nbclassic/static/notebook/js/about.js
+++ b/nbclassic/static/notebook/js/about.js
@@ -10,7 +10,7 @@ requirejs([
     'use strict';
     $('#notebook_about').click(function () {
         // The baseUrlPrefix is only injected in the document by nbclassic.
-        const is_nbclassic = document.baseUrlPrefix !== undefined;
+        var is_nbclassic = document.baseUrlPrefix !== undefined;
         // use underscore template to auto html escape
         if (sys_info) {
           var text = '';


### PR DESCRIPTION
https://github.com/jupyter/nbclassic/pull/156 has introduced a regression for the js-test, using `const` keyword in the javascript which does not seem to be supported by the tests.

This PR fixed this issue.