### PR TITLE
Allow NBClassic to work with NB7 and ServerApp.base_url

### DIFF
--- a/nbclassic/__init__.py
+++ b/nbclassic/__init__.py
@@ -55,7 +55,7 @@ DEFAULT_TEMPLATE_PATH_LIST = [
 ]
 
 
-def url_prefix_notebook():
+def nbclassic_path():
     if NOTEBOOK_V7_DETECTED:
         return "/nbclassic"
     return ""

--- a/nbclassic/bundler/handlers.py
+++ b/nbclassic/bundler/handlers.py
@@ -7,7 +7,7 @@ import asyncio
 import inspect
 import concurrent.futures
 
-from nbclassic import url_prefix_notebook
+from nbclassic import nbclassic_path
 
 from traitlets.utils.importstring import import_item
 from tornado import web, gen
@@ -15,8 +15,6 @@ from tornado import web, gen
 from jupyter_server.utils import url2path
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.services.config import ConfigManager
-
-from nbclassic import url_prefix_notebook
 
 from . import tools
 
@@ -108,5 +106,5 @@ class BundlerHandler(JupyterHandler):
 
 
 default_handlers = [
-    (r"%s/bundle/(.*)" % url_prefix_notebook(), BundlerHandler)
+    (r"%s/bundle/(.*)" % nbclassic_path(), BundlerHandler)
 ]

--- a/nbclassic/edit/handlers.py
+++ b/nbclassic/edit/handlers.py
@@ -13,7 +13,7 @@ from jupyter_server.extension.handler import (
     ExtensionHandlerJinjaMixin
 )
 
-from nbclassic import url_prefix_notebook
+from nbclassic import nbclassic_path
 
 
 class EditorHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandler):
@@ -35,5 +35,5 @@ class EditorHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHa
 
 
 default_handlers = [
-    (r"{}/edit{}".format(url_prefix_notebook(), path_regex), EditorHandler),
+    (r"{}/edit{}".format(nbclassic_path(), path_regex), EditorHandler),
 ]

--- a/nbclassic/notebook/handlers.py
+++ b/nbclassic/notebook/handlers.py
@@ -22,7 +22,7 @@ from jupyter_server.extension.handler import (
 from jupyter_server.base.handlers import JupyterHandler
 HTTPError = web.HTTPError
 
-from nbclassic import url_prefix_notebook
+from nbclassic import nbclassic_path
 
 
 def get_frontend_exporters():
@@ -114,5 +114,5 @@ class NotebookHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, Jupyter
 
 
 default_handlers = [
-    (r"{}/notebooks{}".format(url_prefix_notebook(), path_regex), NotebookHandler),
+    (r"{}/notebooks{}".format(nbclassic_path(), path_regex), NotebookHandler),
 ]

--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -16,7 +16,7 @@ import nbclassic
 from nbclassic import (
     DEFAULT_STATIC_FILES_PATH,
     DEFAULT_TEMPLATE_PATH_LIST,
-    url_prefix_notebook
+    nbclassic_path
 )
 
 from nbclassic._version import __version__
@@ -118,7 +118,7 @@ class NotebookApp(
     extension_url = "/tree"
     subcommands = {}
 
-    default_url = Unicode("%s/tree" % url_prefix_notebook()).tag(config=True)
+    default_url = Unicode("%s/tree" % nbclassic_path()).tag(config=True)
 
     # Override the default open_Browser trait in ExtensionApp,
     # setting it to True.
@@ -194,7 +194,7 @@ class NotebookApp(
         nbui = gettext.translation('nbui', localedir=os.path.join(
             base_dir, 'nbclassic/i18n'), fallback=True)
         self.jinja2_env.install_gettext_translations(nbui, newstyle=False)
-        self.jinja2_env.globals.update(base_url_prefix=url_prefix_notebook)
+        self.jinja2_env.globals.update(nbclassic_path=nbclassic_path)
 
     def _link_jupyter_server_extension(self, serverapp):
         # Monkey-patch Jupyter Server's and nbclassic's static path list to include

--- a/nbclassic/static/edit/js/menubar.js
+++ b/nbclassic/static/edit/js/menubar.js
@@ -28,7 +28,7 @@ define([
          *          file_path : string
          */
         options = options || {};
-        this.base_url_prefix = options.base_url_prefix;
+        this.nbclassic_path = options.nbclassic_path;
         this.base_url = options.base_url || utils.get_body_data("baseUrl");
         this.selector = selector;
         this.editor = options.editor;
@@ -55,7 +55,7 @@ define([
             editor.contents.new_untitled(parent, {type: "file"}).then(
                 function (data) {
                     w.location = utils.url_path_join(
-                        that.base_url, that.base_url_prefix, 'edit', utils.encode_uri_components(data.path)
+                        that.base_url, that.nbclassic_path, 'edit', utils.encode_uri_components(data.path)
                     );
                 },
                 function(error) {

--- a/nbclassic/static/edit/js/menubar.js
+++ b/nbclassic/static/edit/js/menubar.js
@@ -55,7 +55,7 @@ define([
             editor.contents.new_untitled(parent, {type: "file"}).then(
                 function (data) {
                     w.location = utils.url_path_join(
-                        that.base_url_prefix, that.base_url, 'edit', utils.encode_uri_components(data.path)
+                        that.base_url, that.base_url_prefix, 'edit', utils.encode_uri_components(data.path)
                     );
                 },
                 function(error) {

--- a/nbclassic/static/notebook/js/about.js
+++ b/nbclassic/static/notebook/js/about.js
@@ -9,8 +9,8 @@ requirejs([
 ], function ($, dialog, i18n, _, IPython) {
     'use strict';
     $('#notebook_about').click(function () {
-        // The baseUrlPrefix is only injected in the document by nbclassic.
-        var is_nbclassic = document.baseUrlPrefix !== undefined;
+        // The nbclassicPath is only injected in the document by nbclassic.
+        var is_nbclassic = document.nbclassicPath !== undefined;
         // use underscore template to auto html escape
         if (sys_info) {
           var text = '';

--- a/nbclassic/static/notebook/js/kernelselector.js
+++ b/nbclassic/static/notebook/js/kernelselector.js
@@ -15,7 +15,7 @@ define([
         var that = this;
         this.selector = selector;
         this.notebook = notebook;
-        this.base_url_prefix = options.base_url_prefix;
+        this.nbclassic_path = options.nbclassic_path;
         this.notebook.set_kernelselector(this);
         this.events = notebook.events;
         this.current_selection = null;
@@ -309,7 +309,7 @@ define([
         that.notebook.contents.new_untitled(parent, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(
-                    that.notebook.base_url, that.base_url_prefix,  'notebooks',
+                    that.notebook.base_url, that.nbclassic_path, 'notebooks',
                     utils.encode_uri_components(data.path)
                 );
                 url += "?kernel_name=" + kernel_name;

--- a/nbclassic/static/notebook/js/kernelselector.js
+++ b/nbclassic/static/notebook/js/kernelselector.js
@@ -10,10 +10,12 @@ define([
 ], function($, IPython, dialog, utils, i18n) {
     "use strict";
     
-    var KernelSelector = function(selector, notebook) {
+    var KernelSelector = function(selector, notebook, options) {
+        options = options || {};
         var that = this;
         this.selector = selector;
         this.notebook = notebook;
+        this.base_url_prefix = options.base_url_prefix;
         this.notebook.set_kernelselector(this);
         this.events = notebook.events;
         this.current_selection = null;
@@ -307,7 +309,7 @@ define([
         that.notebook.contents.new_untitled(parent, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(
-                    that.notebook.base_url, 'notebooks',
+                    that.notebook.base_url, that.base_url_prefix,  'notebooks',
                     utils.encode_uri_components(data.path)
                 );
                 url += "?kernel_name=" + kernel_name;

--- a/nbclassic/static/notebook/js/main.js
+++ b/nbclassic/static/notebook/js/main.js
@@ -104,7 +104,7 @@ requirejs([
     var common_options = {
         ws_url : utils.get_body_data("wsUrl"),
         base_url : utils.get_body_data("baseUrl"),
-        base_url_prefix: document.baseUrlPrefix || "",
+        nbclassic_path: document.nbclassicPath || "",
         notebook_path : utils.get_body_data("notebookPath"),
         notebook_name : utils.get_body_data('notebookName')
     };

--- a/nbclassic/static/notebook/js/main.js
+++ b/nbclassic/static/notebook/js/main.js
@@ -104,6 +104,7 @@ requirejs([
     var common_options = {
         ws_url : utils.get_body_data("wsUrl"),
         base_url : utils.get_body_data("baseUrl"),
+        base_url_prefix: document.baseUrlPrefix || "",
         notebook_path : utils.get_body_data("notebookPath"),
         notebook_name : utils.get_body_data('notebookName')
     };
@@ -168,7 +169,7 @@ requirejs([
         keyboard_manager: keyboard_manager});
     notification_area.init_notification_widgets();
     var kernel_selector = new kernelselector.KernelSelector(
-        '#kernel_logo_widget', notebook);
+        '#kernel_logo_widget', notebook, common_options);
     searchandreplace.load(keyboard_manager);
 
     $('body').append('<div id="fonttest"><pre><span id="test1">x</span>'+

--- a/nbclassic/static/notebook/js/menubar.js
+++ b/nbclassic/static/notebook/js/menubar.js
@@ -36,7 +36,7 @@ define([
          *          config: ConfigSection instance
          */
         options = options || {};
-        this.base_url_prefix = options.base_url_prefix;
+        this.nbclassic_path = options.nbclassic_path;
         this.base_url = options.base_url || utils.get_body_data("baseUrl");
         this.selector = selector;
         this.notebook = options.notebook;
@@ -178,7 +178,7 @@ define([
             var parent = utils.url_path_split(that.notebook.notebook_path)[0];
             window.open(
                 utils.url_path_join(
-                    that.base_url, that.base_url_prefix, 'tree',
+                    that.base_url, that.nbclassic_path, 'tree',
                     utils.encode_uri_components(parent)
                 ), IPython._target);
         });

--- a/nbclassic/static/notebook/js/menubar.js
+++ b/nbclassic/static/notebook/js/menubar.js
@@ -178,7 +178,7 @@ define([
             var parent = utils.url_path_split(that.notebook.notebook_path)[0];
             window.open(
                 utils.url_path_join(
-                    that.base_url_prefix, that.base_url, 'tree',
+                    that.base_url, that.base_url_prefix, 'tree',
                     utils.encode_uri_components(parent)
                 ), IPython._target);
         });

--- a/nbclassic/static/notebook/js/notebook.js
+++ b/nbclassic/static/notebook/js/notebook.js
@@ -90,7 +90,7 @@ define([
         this.config.loaded.then(this.validate_config.bind(this));
         this.class_config = new configmod.ConfigWithDefaults(this.config, 
                                         Notebook.options_default, 'Notebook');
-        this.base_url_prefix = options.base_url_prefix;
+        this.nbclassic_path = options.nbclassic_path;
         this.base_url = options.base_url;
         this.notebook_path = options.notebook_path;
         this.notebook_name = options.notebook_name;

--- a/nbclassic/static/services/config.js
+++ b/nbclassic/static/services/config.js
@@ -8,7 +8,7 @@ function(utils) {
     "use strict";
     var ConfigSection = function(section_name, options) {
         this.section_name = section_name;
-        this.base_url_prefix = options.base_url_prefix;
+        this.nbclassic_path = options.nbclassic_path;
         this.base_url = options.base_url;
         this.data = {};
         

--- a/nbclassic/static/services/contents.js
+++ b/nbclassic/static/services/contents.js
@@ -23,7 +23,7 @@ define(function(requirejs) {
          *      Dictionary of keyword arguments.
          *          base_url: string
          */
-         this.base_url_prefix = options.base_url_prefix;
+         this.nbclassic_path = options.nbclassic_path;
          this.base_url = options.base_url;
     };
 

--- a/nbclassic/static/services/sessions/session.js
+++ b/nbclassic/static/services/sessions/session.js
@@ -36,7 +36,7 @@ define([
             name: options.kernel_name
         };
 
-        this.base_url_prefix = options.base_url_prefix;
+        this.nbclassic_path = options.nbclassic_path;
         this.base_url = options.base_url;
         this.ws_url = options.ws_url;
         this.session_service_url = utils.url_path_join(this.base_url, 'api/sessions');

--- a/nbclassic/static/terminal/js/main.js
+++ b/nbclassic/static/terminal/js/main.js
@@ -23,6 +23,7 @@ requirejs([
 
     var common_options = {
         base_url : utils.get_body_data("baseUrl"),
+        nbclassic_path: document.nbclassicPath || ""
     };
 
     var config = new configmod.ConfigSection('terminal', common_options);

--- a/nbclassic/static/tree/js/main.js
+++ b/nbclassic/static/tree/js/main.js
@@ -74,7 +74,7 @@ requirejs([
 
     var common_options = {
         base_url: utils.get_body_data("baseUrl"),
-        base_url_prefix: document.baseUrlPrefix || "",
+        nbclassic_path: document.nbclassicPath || "",
         notebook_path: utils.get_body_data("notebookPath"),
     };
     var cfg = new config.ConfigSection('tree', common_options);

--- a/nbclassic/static/tree/js/newnotebook.js
+++ b/nbclassic/static/tree/js/newnotebook.js
@@ -85,7 +85,7 @@ define([
         this.contents.new_untitled(dir_path, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(
-                    that.base_url_prefix, that.base_url, 'notebooks',
+                    that.base_url, that.base_url_prefix, 'notebooks',
                     utils.encode_uri_components(data.path)
                 );
                 if (kernel_name) {

--- a/nbclassic/static/tree/js/newnotebook.js
+++ b/nbclassic/static/tree/js/newnotebook.js
@@ -12,7 +12,7 @@ define([
     
     var NewNotebookWidget = function (selector, options) {
         this.selector = selector;
-        this.base_url_prefix = options.base_url_prefix;
+        this.nbclassic_path = options.nbclassic_path;
         this.base_url = options.base_url;
         this.contents = options.contents;
         this.events = options.events;
@@ -85,7 +85,7 @@ define([
         this.contents.new_untitled(dir_path, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(
-                    that.base_url, that.base_url_prefix, 'notebooks',
+                    that.base_url, that.nbclassic_path, 'notebooks',
                     utils.encode_uri_components(data.path)
                 );
                 if (kernel_name) {

--- a/nbclassic/static/tree/js/notebooklist.js
+++ b/nbclassic/static/tree/js/notebooklist.js
@@ -171,7 +171,7 @@ define([
                 var w = window.open('', IPython._target);
                 that.contents.new_untitled(that.notebook_path || '', {type: 'file', ext: '.txt'}).then(function(data) {
                     w.location = utils.url_path_join(
-                        that.base_url_prefix, that.base_url, 'edit',
+                        that.base_url, that.base_url_prefix, 'edit',
                         utils.encode_uri_components(data.path)
                     );
                 }).catch(function (e) {
@@ -385,7 +385,7 @@ define([
         var breadcrumb = $('.breadcrumb');
         breadcrumb.empty();
         var list_item = $('<li/>');
-        var root_url = utils.url_path_join(that.base_url_prefix, that.base_url, '/tree');
+        var root_url = utils.url_path_join(that.base_url, that.base_url_prefix, '/tree');
         var root = $('<li/>').append(
             $("<a/>")
             .attr('href', root_url)
@@ -403,7 +403,7 @@ define([
                 window.history.pushState(
                     {path: path},
                     'Home',
-                    utils.url_path_join(that.base_url_prefix, that.base_url, 'tree')
+                    utils.url_path_join(that.base_url, that.base_url_prefix, 'tree')
                 );
                 that.update_location(path);
                 return false;
@@ -415,8 +415,8 @@ define([
             path_parts.push(path_part);
             var path = path_parts.join('/');
             var url = utils.url_path_join(
-                that.base_url_prefix,
                 that.base_url,
+                that.base_url_prefix,
                 '/tree',
                 utils.encode_uri_components(path)
             );
@@ -907,8 +907,8 @@ define([
         var link = item.find("a.item_link")
             .attr('href',
                 utils.url_path_join(
-                    this.base_url_prefix,
                     this.base_url,
+                    this.base_url_prefix,
                     uri_prefix,
                     utils.encode_uri_components(model.path)
                 )
@@ -931,8 +931,8 @@ define([
                 window.history.pushState({
                     path: model.path
                 }, model.path, utils.url_path_join(
-                    that.base_url_prefix,
                     that.base_url,
+                    that.base_url_prefix,
                     'tree',
                     utils.encode_uri_components(model.path)
                 ));

--- a/nbclassic/static/tree/js/notebooklist.js
+++ b/nbclassic/static/tree/js/notebooklist.js
@@ -120,7 +120,7 @@ define([
         }
         this.notebooks_list = [];
         this.sessions = {};
-        this.base_url_prefix = options.base_url_prefix;
+        this.nbclassic_path = options.nbclassic_path;
         this.base_url = options.base_url || utils.get_body_data("baseUrl");
         this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
         this.initial_notebook_path = this.notebook_path;
@@ -171,7 +171,7 @@ define([
                 var w = window.open('', IPython._target);
                 that.contents.new_untitled(that.notebook_path || '', {type: 'file', ext: '.txt'}).then(function(data) {
                     w.location = utils.url_path_join(
-                        that.base_url, that.base_url_prefix, 'edit',
+                        that.base_url, that.nbclassic_path, 'edit',
                         utils.encode_uri_components(data.path)
                     );
                 }).catch(function (e) {
@@ -385,7 +385,7 @@ define([
         var breadcrumb = $('.breadcrumb');
         breadcrumb.empty();
         var list_item = $('<li/>');
-        var root_url = utils.url_path_join(that.base_url, that.base_url_prefix, '/tree');
+        var root_url = utils.url_path_join(that.base_url, that.nbclassic_path, '/tree');
         var root = $('<li/>').append(
             $("<a/>")
             .attr('href', root_url)
@@ -403,7 +403,7 @@ define([
                 window.history.pushState(
                     {path: path},
                     'Home',
-                    utils.url_path_join(that.base_url, that.base_url_prefix, 'tree')
+                    utils.url_path_join(that.base_url, that.nbclassic_path, 'tree')
                 );
                 that.update_location(path);
                 return false;
@@ -416,7 +416,7 @@ define([
             var path = path_parts.join('/');
             var url = utils.url_path_join(
                 that.base_url,
-                that.base_url_prefix,
+                that.nbclassic_path,
                 '/tree',
                 utils.encode_uri_components(path)
             );
@@ -908,7 +908,7 @@ define([
             .attr('href',
                 utils.url_path_join(
                     this.base_url,
-                    this.base_url_prefix,
+                    this.nbclassic_path,
                     uri_prefix,
                     utils.encode_uri_components(model.path)
                 )
@@ -932,7 +932,7 @@ define([
                     path: model.path
                 }, model.path, utils.url_path_join(
                     that.base_url,
-                    that.base_url_prefix,
+                    that.nbclassic_path,
                     'tree',
                     utils.encode_uri_components(model.path)
                 ));

--- a/nbclassic/static/tree/js/sessionlist.js
+++ b/nbclassic/static/tree/js/sessionlist.js
@@ -21,7 +21,7 @@ define([
          */
         this.events = options.events;
         this.sessions = {};
-        this.base_url_prefix = options.base_url_prefix;
+        this.nbclassic_path = options.nbclassic_path;
         this.base_url = options.base_url || utils.get_body_data("baseUrl");
 
         // Add collapse arrows.

--- a/nbclassic/static/tree/js/terminallist.js
+++ b/nbclassic/static/tree/js/terminallist.js
@@ -20,7 +20,7 @@ define([
          *      Dictionary of keyword arguments.
          *          base_url: string
          */
-         this.base_url_prefix = options.base_url_prefix;
+         this.nbclassic_path = options.nbclassic_path;
          this.base_url = options.base_url || utils.get_body_data("baseUrl");
         this.element_name = options.element_name || 'running';
         this.selector = selector;

--- a/nbclassic/templates/page.html
+++ b/nbclassic/templates/page.html
@@ -21,7 +21,7 @@
     <script src="{{static_url('components/create-react-class/index.js')}}" type="text/javascript"></script>
     <script src="{{static_url('components/requirejs/require.js') }}" type="text/javascript" charset="utf-8"></script>
     <script>
-      document.baseUrlPrefix = '{{base_url_prefix()}}';
+      document.nbclassicPath = '{{nbclassic_path()}}';
       require.config({
           {% if version_hash %}
           urlArgs: "v={{version_hash}}",

--- a/nbclassic/tree/handlers.py
+++ b/nbclassic/tree/handlers.py
@@ -17,7 +17,7 @@ from jupyter_server.extension.handler import (
 from jupyter_server.base.handlers import path_regex
 from jupyter_server.utils import url_path_join, url_escape
 
-from nbclassic import url_prefix_notebook
+from nbclassic import nbclassic_path
 
 
 class TreeHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandler):
@@ -84,6 +84,6 @@ class TreeHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHand
 
 
 default_handlers = [
-    (r"{}/tree{}".format(url_prefix_notebook(), path_regex), TreeHandler),
-    (r"%s/tree" % url_prefix_notebook(), TreeHandler),
+    (r"{}/tree{}".format(nbclassic_path(), path_regex), TreeHandler),
+    (r"%s/tree" % nbclassic_path(), TreeHandler),
 ]


### PR DESCRIPTION
To test, upgrade to Notebook v7 and Lab v4, install this NBClassic, set ServerApp.base_url, run Jupyter, visit nbclassic

Also resolves an issue where New->New Notebook did not add the "/nbclassic/" in the url when Notebook v7 was installed

Personally not a fan of the var still being called base_url_prefix but I didn't want to change that unilaterally. 

Closes #164