### PR TITLE
Fix/nbclassic base url

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -195,6 +195,7 @@ class NotebookApp(
             base_dir, 'nbclassic/i18n'), fallback=True)
         self.jinja2_env.install_gettext_translations(nbui, newstyle=False)
         self.jinja2_env.globals.update(nbclassic_path=nbclassic_path)
+        self.jinja2_env.globals.update(nbclassic_tree=url_path_join(self.serverapp.base_url, nbclassic_path(), "tree"))
 
     def _link_jupyter_server_extension(self, serverapp):
         # Monkey-patch Jupyter Server's and nbclassic's static path list to include

--- a/nbclassic/templates/page.html
+++ b/nbclassic/templates/page.html
@@ -139,7 +139,7 @@ dir="ltr">
 <div id="header" role="navigation" aria-label="{% trans %}Top Menu{% endtrans %}">
   <div id="header-container" class="container">
   <div id="ipython_notebook" class="nav navbar-brand"><a href="
-    {%- if nbclassic_path()|length > 0 -%}{{base_url}}{{nbclassic_path() | replace("/","",1)}}{%- else -%}{{default_url}}{%- endif -%}
+    {%- if nbclassic_tree|length > 0 -%}{{nbclassic_tree}}{%- else -%}{{default_url}}{%- endif -%}
     {%- if logged_in and token -%}?token={{token}}{%- endif -%}" title='{% trans %}dashboard{% endtrans %}'>
       {% block logo %}<img src='{{static_url("base/images/logo.png") }}' alt='Jupyter Notebook'/>{% endblock %}
   </a></div>

--- a/nbclassic/templates/page.html
+++ b/nbclassic/templates/page.html
@@ -138,7 +138,8 @@ dir="ltr">
 
 <div id="header" role="navigation" aria-label="{% trans %}Top Menu{% endtrans %}">
   <div id="header-container" class="container">
-  <div id="ipython_notebook" class="nav navbar-brand"><a href="{{default_url}}
+  <div id="ipython_notebook" class="nav navbar-brand"><a href="
+    {%- if nbclassic_path()|length > 0 -%}{{base_url}}{{nbclassic_path() | replace("/","",1)}}{%- else -%}{{default_url}}{%- endif -%}
     {%- if logged_in and token -%}?token={{token}}{%- endif -%}" title='{% trans %}dashboard{% endtrans %}'>
       {% block logo %}<img src='{{static_url("base/images/logo.png") }}' alt='Jupyter Notebook'/>{% endblock %}
   </a></div>


### PR DESCRIPTION
This will ensure that the "Dashboard" link at the top left of Notebookv6/NBClassic always points back to the tree view no matter how jupyter was launched.
Closes #167 