### PR TITLE
Update docs to remove install command

### DIFF
--- a/docs/source/nbclassic_dev_faq.rst
+++ b/docs/source/nbclassic_dev_faq.rst
@@ -83,5 +83,4 @@ pending to be merged into the `Jupyter-contrib/jupyter_nbextensions_configurator
     $ pip install jupyter_nbextensions_configurator
     $ jupyter nbextension install --sys-prefix --py jupyter_nbextensions_configurator --overwrite
     $ jupyter nbextension enable --sys-prefix --py jupyter_nbextensions_configurator
-    $ jupyter serverextension install --sys-prefix --py jupyter_nbextensions_configurator --overwrite
     $ jupyter serverextension enable --sys-prefix --py jupyter_nbextensions_configurator


### PR DESCRIPTION
There is no `jupyter serverextension install` command