### PR TITLE
Documentation for the extensions configurator

### DIFF
--- a/docs/source/nbclassic_dev_faq.rst
+++ b/docs/source/nbclassic_dev_faq.rst
@@ -80,7 +80,7 @@ pending to be merged into the `Jupyter-contrib/jupyter_nbextensions_configurator
 
     Once a release with this fix is available, users will be able to activate the extension with the following commands::
 
-    $ pip install jupyter_nbextensions_configurator
-    $ jupyter nbextension install --sys-prefix --py jupyter_nbextensions_configurator --overwrite
-    $ jupyter nbextension enable --sys-prefix --py jupyter_nbextensions_configurator
-    $ jupyter serverextension enable --sys-prefix --py jupyter_nbextensions_configurator
+    $ pip install 'jupyter_nbextensions_configurator @ git+https://github.com/datalayer-externals/jupyter-notebook-configurator.git@fix/nbclassic#egg=jupyter_nbextensions_configurator'
+    $ jupyter nbclassic-extension install --sys-prefix --py jupyter_nbextensions_configurator --overwrite
+    $ jupyter nbclassic-extension enable --sys-prefix --py jupyter_nbextensions_configurator
+    $ jupyter nbclassic-serverextension enable --sys-prefix --py jupyter_nbextensions_configurator

--- a/nbclassic/static/base/js/namespace.js
+++ b/nbclassic/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "0.4.7";
+    Jupyter.version = "0.5.0.dev0";
     Jupyter._target = '_blank';
 
     return Jupyter;


### PR DESCRIPTION
 Correct documentation for the commands to enable the `jupyter_nbextensions_configurator`

(this also contains changes to move back to dev version for `Jupyter.version`)