### PR TITLE
Revert pull request 168

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -195,7 +195,6 @@ class NotebookApp(
             base_dir, 'nbclassic/i18n'), fallback=True)
         self.jinja2_env.install_gettext_translations(nbui, newstyle=False)
         self.jinja2_env.globals.update(nbclassic_path=nbclassic_path)
-        self.jinja2_env.globals.update(nbclassic_tree=url_path_join(self.serverapp.base_url, nbclassic_path(), "tree"))
 
     def _link_jupyter_server_extension(self, serverapp):
         # Monkey-patch Jupyter Server's and nbclassic's static path list to include

--- a/nbclassic/static/base/js/namespace.js
+++ b/nbclassic/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "0.4.8";
+    Jupyter.version = "0.5.0.dev0";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/nbclassic/templates/page.html
+++ b/nbclassic/templates/page.html
@@ -139,7 +139,7 @@ dir="ltr">
 <div id="header" role="navigation" aria-label="{% trans %}Top Menu{% endtrans %}">
   <div id="header-container" class="container">
   <div id="ipython_notebook" class="nav navbar-brand"><a href="
-    {%- if nbclassic_tree|length > 0 -%}{{nbclassic_tree}}{%- else -%}{{default_url}}{%- endif -%}
+    <div id="ipython_notebook" class="nav navbar-brand"><a href="{{default_url}}
     {%- if logged_in and token -%}?token={{token}}{%- endif -%}" title='{% trans %}dashboard{% endtrans %}'>
       {% block logo %}<img src='{{static_url("base/images/logo.png") }}' alt='Jupyter Notebook'/>{% endblock %}
   </a></div>


### PR DESCRIPTION
Fixes https://github.com/jupyter/nbclassic/issues/182

There are a lot of moving parts when having multiple Jupyter frontends installed. 

https://github.com/jupyter/nbclassic/pull/168 was tackling some cases, but has introduced changes in behavior for logo url in case of `default_url` being overriden https://github.com/jupyter/nbclassic/issues/182

This PR reverts https://github.com/jupyter/nbclassic/pull/168

cc/ @mcrutch