### PR TITLE
Add pytest_jupyter to the list of test deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ test =
     nbval
     pytest-playwright
     pytest-cov
+    pytest_jupyter
     pytest_tornasync
     requests-unixsocket; sys_platform != "win32"
 docs =


### PR DESCRIPTION
Add pytest_jupyter to the list of test deps to fix CI failure happening on https://github.com/jupyter/nbclassic/actions/runs/3645990567/jobs/6156710018