### PR TITLE
remove unused pytest_tornasync dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,6 @@ test =
     pytest-playwright
     pytest-cov
     pytest_jupyter
-    pytest_tornasync
     requests-unixsocket; sys_platform != "win32"
 docs =
     sphinx


### PR DESCRIPTION
Fixes https://github.com/jupyter/nbclassic/issues/198