### PR TITLE
Ci test fixes round1

### DIFF
--- a/nbclassic/tests/end_to_end/test_save.py
+++ b/nbclassic/tests/end_to_end/test_save.py
@@ -45,7 +45,7 @@ def test_save(notebook_frontend):
     checkpoints = notebook_frontend.evaluate("() => Jupyter.notebook.checkpoints", page=EDITOR_PAGE)
     assert len(checkpoints) == 1
 
-    notebook_frontend.try_click_selector('#ipython_notebook a', page=EDITOR_PAGE)
+    notebook_frontend.try_click_selector('#ipython_notebook', page=EDITOR_PAGE)
     notebook_frontend.wait_for_selector('.item_link', page=EDITOR_PAGE)
 
     hrefs_nonmatch = []


### PR DESCRIPTION
This PR fixes the `locator resolved to 2 elements` error in `test_save.py` (by revising the locator).