### PR TITLE
Don't require two different minimal versions of jupyter_server

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     traitlets>=4.2.1
     jupyter_core>=4.6.1
     jupyter_client>=6.1.1
-    jupyter_server>=1.17.0
     ipython_genutils
     jupyter_server>=1.8
     nbformat


### PR DESCRIPTION
It works but is confusing.