### PR TITLE
CI Test Fixes Round 2

### DIFF
--- a/nbclassic/tests/end_to_end/test_save_readonly_as.py
+++ b/nbclassic/tests/end_to_end/test_save_readonly_as.py
@@ -68,7 +68,7 @@ def test_save_readonly_as(notebook_frontend):
             save_as(notebook_frontend)
             try:
                 name_input_element.wait_for('visible')
-            except Exception as err:
+            except PlaywrightTimeoutError as err:
                 print('[Test] Error waiting for save prompt')
                 return False
 
@@ -102,7 +102,7 @@ def test_save_readonly_as(notebook_frontend):
             print('[Test] Save element still visible after save, wait for hidden')
             try:
                 save_element.expect_not_to_be_visible(timeout=120)
-            except Exception as err:
+            except PlaywrightTimeoutError as err:
                 traceback.print_exc()
                 print('[Test]   Save button failed to hide...')
 

--- a/nbclassic/tests/end_to_end/test_save_readonly_as.py
+++ b/nbclassic/tests/end_to_end/test_save_readonly_as.py
@@ -1,6 +1,8 @@
 """Test readonly notebook saved and renamed"""
 
 
+import traceback
+
 from .utils import EDITOR_PAGE
 from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeoutError
 
@@ -9,9 +11,11 @@ def save_as(nb):
     JS = '() => Jupyter.notebook.save_notebook_as()'
     return nb.evaluate(JS, page=EDITOR_PAGE)
 
+
 def get_notebook_name(nb):
     JS = '() => Jupyter.notebook.notebook_name'
     return nb.evaluate(JS, page=EDITOR_PAGE)
+
 
 def set_notebook_name(nb, name):
     JS = f'() => Jupyter.notebook.rename("{name}")'
@@ -19,43 +23,84 @@ def set_notebook_name(nb, name):
 
 
 def test_save_readonly_as(notebook_frontend):
+    print('[Test] [test_save_readonly_as]')
     notebook_frontend.edit_cell(index=0, content='a=10; print(a)')
     notebook_frontend.wait_for_kernel_ready()
     notebook_frontend.wait_for_selector(".input", page=EDITOR_PAGE)
 
     # Set a name for comparison later
+    print('[Test] Set notebook name')
     set_notebook_name(notebook_frontend, name="nb1.ipynb")
     assert get_notebook_name(notebook_frontend) == "nb1.ipynb"
 
     # Wait for Save As modal, save
+    print('[Test] Save')
     save_as(notebook_frontend)
 
-    # Wait for modal to pop up
-    notebook_frontend.wait_for_selector('//input[@data-testid="save-as"]', page=EDITOR_PAGE)
+    # # Wait for modal to pop up
+    print('[Test] Waiting for modal popup')
+    notebook_frontend.wait_for_selector(".modal-footer", page=EDITOR_PAGE)
+    dialog_element = notebook_frontend.locate(".modal-footer", page=EDITOR_PAGE)
+    dialog_element.focus()
 
-    # TODO: Add a function for locator assertions to FrontendElement
-    locator_element = notebook_frontend.locate_and_focus('//input[@data-testid="save-as"]', page=EDITOR_PAGE)
-    locator_element.wait_for('visible')
+    print('[Test] Focus the notebook name input field, then click and modify its .value')
+    notebook_frontend.wait_for_selector('.modal-body .form-control', page=EDITOR_PAGE)
+    name_input_element = notebook_frontend.locate('.modal-body .form-control', page=EDITOR_PAGE)
+    name_input_element.focus()
+    name_input_element.click()
 
-    modal_footer = notebook_frontend.locate('.modal-footer', page=EDITOR_PAGE)
-    modal_footer.wait_for('visible')
-    
-    notebook_frontend.insert_text('new_notebook.ipynb', page=EDITOR_PAGE)
+    # Begin attempts to fill the save dialog input and save the notebook
+    fill_attempts = 1
 
-    save_btn = modal_footer.locate('text=Save')
-    save_btn.wait_for('visible')
-    save_btn.click()
-    # notebook_frontend.try_click_selector('//html//body//div[8]//div//div//div[3]//button[2]', page=EDITOR_PAGE)
+    def attempt_form_fill_and_save():
+        # This process is SUPER flaky, we use this for repeated attempts
+        nonlocal fill_attempts
+        print(f'[Test] Attempt form fill and save #{fill_attempts}')
+        if fill_attempts >= 1 and get_notebook_name(notebook_frontend) == "new_notebook.ipynb":
+            print('[Test]   Success from previous save attempt!')
+            return True
+        fill_attempts += 1
 
-    # locator_element.expect_not_to_be_visible()
-    notebook_frontend.wait_for_condition(
-        lambda: get_notebook_name(notebook_frontend) == "new_notebook.ipynb", timeout=120, period=5
-    )
+        # Set the notebook name field in the save dialog
+        print('[Test] Fill the input field')
+        name_input_element.evaluate(f'(elem) => {{ elem.value = "new_notebook.ipynb"; return elem.value; }}')
+        notebook_frontend.wait_for_condition(
+            lambda: name_input_element.evaluate(
+                f'(elem) => {{ elem.value = "new_notebook.ipynb"; return elem.value; }}') == 'new_notebook.ipynb',
+            timeout=120,
+            period=.25
+        )
+        # Show the input field value
+        print('[Test] Name input field contents:')
+        field_value = name_input_element.evaluate(f'(elem) => {{ return elem.value; }}')
+        print('[Test]   ' + field_value)
+        if field_value != 'new_notebook.ipynb':
+            return False
 
-    # notebook_frontend.locate('#notebook_name', page=EDITOR_PAGE)
+        print('[Test] Locate and click the save button')
+        save_element = dialog_element.locate('text=Save')
+        save_element.wait_for('visible')
+        save_element.focus()
+        save_element.click()
 
-    # # Test that the name changed
-    # assert get_notebook_name(notebook_frontend) == "new_notebook.ipynb"
+        if save_element.is_visible():
+            print('[Test] Save element still visible after save, wait for hidden')
+            try:
+                save_element.expect_not_to_be_visible(timeout=120)
+            except Exception as err:
+                traceback.print_exc()
+                print('[Test]   Save button failed to hide...')
+
+        notebook_frontend.wait_for_condition(
+            lambda: get_notebook_name(notebook_frontend) == "new_notebook.ipynb", timeout=120, period=5
+        )
+        print(f'[Test] Notebook name: {get_notebook_name(notebook_frontend)}')
+        print('[Test] Notebook name was changed!')
+        return True
+
+    # Retry until timeout, this process is *very* flaky
+    notebook_frontend.wait_for_condition(attempt_form_fill_and_save, timeout=900, period=1)
 
     # Test that address bar was updated
+    print('[Test] Test address bar')
     assert "new_notebook.ipynb" in notebook_frontend.get_page_url(page=EDITOR_PAGE)

--- a/nbclassic/tests/end_to_end/utils.py
+++ b/nbclassic/tests/end_to_end/utils.py
@@ -173,9 +173,10 @@ class FrontendElement:
         """Currently this is an unmanaged user data area, use it as you please"""
         return self._user_data
 
-    def expect_not_to_be_visible(self):
+    def expect_not_to_be_visible(self, timeout=30):
+        seconds_to_milliseconds = 1000
         try:
-            expect(self._element).not_to_be_visible()
+            expect(self._element).not_to_be_visible(timeout=timeout * seconds_to_milliseconds)
         except ValueError as err:
             raise Exception('Cannot expect not_to_be_visible on this type!') from err
 


### PR DESCRIPTION
This PR fixes `test_save_readonly_as.py` errors. This update reflects a new testing approach that better handles the variability in test behaviors and execution times experienced in CI and local test runs (There's less reliance on _**application state transitions that happen in a user workflow**_ to advance the testing procedure forward).

- The save prompt may close instantaneously, or linger for a long time...the test now handles both of these scenarios
- New locators and checks are used to drive the test forward
- Diagnostic messages are now printed during different test steps, to provide data and debugging information for both successful and unsuccessful test runs

See also, previous related PRs ([this](https://github.com/jupyter/nbclassic/pull/202) and [this](https://github.com/jupyter/nbclassic/pull/195/files)).