### PR TITLE
Fix generating of .mo and .json files for nl translation

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -347,9 +347,9 @@ class CompileBackendTranslation(Command):
 
 
     def run(self):
-        paths = glob('nbclassic/i18n/??_??')
+        paths = glob('nbclassic/i18n/*/LC_MESSAGES')
         for p in paths:
-            LANG = p[-5:]
+            LANG = p.split(os.path.sep)[-2]
             for component in ['nbclassic', 'nbui']:
                 run(['pybabel', 'compile',
                      '-D', component,
@@ -557,7 +557,7 @@ class CompileJS(Command):
         run(['node', 'tools/build-main.js', name])
 
     def build_jstranslation(self, trd):
-        lang = trd[-5:]
+        lang = trd.split(os.path.sep)[-2]
         run([
             pjoin('node_modules', '.bin', 'po2json'),
             '-p', '-F',
@@ -573,7 +573,7 @@ class CompileJS(Command):
         env['PATH'] = npm_path
         pool = ThreadPool()
         pool.map(self.build_main, self.apps)
-        pool.map(self.build_jstranslation, glob('nbclassic/i18n/??_??'))
+        pool.map(self.build_jstranslation, glob('nbclassic/i18n/*/LC_MESSAGES'))
         # update package data in case this created new files
         update_package_data(self.distribution)
 


### PR DESCRIPTION
The previous glob pattern "??_??" does not match /nl/.

Before:
```sh
$ unzip -l dist/nbclassic-0.6.0.dev0-py3-none-any.whl | grep "i18n/nl/"
    19908  02-21-2023 07:52   nbclassic/i18n/nl/LC_MESSAGES/nbclassic.po
    66784  02-21-2023 07:52   nbclassic/i18n/nl/LC_MESSAGES/nbjs.po
    19825  02-21-2023 07:52   nbclassic/i18n/nl/LC_MESSAGES/nbui.po

$ tar -tf dist/nbclassic-0.6.0.dev0.tar.gz | grep "i18n/nl/"
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/nbclassic.po
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/nbjs.po
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/nbui.po
```

After:
```sh
$ unzip -l dist/nbclassic-0.6.0.dev0-py3-none-any.whl | grep "i18n/nl/"
    15500  02-21-2023 09:29   nbclassic/i18n/nl/LC_MESSAGES/nbclassic.mo
    19908  02-21-2023 07:52   nbclassic/i18n/nl/LC_MESSAGES/nbclassic.po
    48832  02-21-2023 09:28   nbclassic/i18n/nl/LC_MESSAGES/nbjs.json
    66784  02-21-2023 07:52   nbclassic/i18n/nl/LC_MESSAGES/nbjs.po
    11803  02-21-2023 09:29   nbclassic/i18n/nl/LC_MESSAGES/nbui.mo
    19825  02-21-2023 07:52   nbclassic/i18n/nl/LC_MESSAGES/nbui.po

$ tar -tf dist/nbclassic-0.6.0.dev0.tar.gz | grep "i18n/nl/"
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/nbclassic.mo
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/nbclassic.po
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/nbjs.json
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/nbjs.po
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/nbui.mo
nbclassic-0.6.0.dev0/nbclassic/i18n/nl/LC_MESSAGES/nbui.po
```