### PR TITLE
Remove redirect from /notebooks to /files

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -254,15 +254,6 @@ class NotebookApp(
         # Default routes
         # Order matters. The first handler to match the URL will handle the request.
         handlers = []
-        # Add a redirect from /notebooks to /files
-        # for opening non-ipynb files in edit mode.
-        handlers.append(
-            (
-                rf"/{self.file_url_prefix}/((?!.*\.ipynb($|\?)).*)",
-                RedirectHandler,
-                {"url": self.serverapp.base_url+"files/{0}"}
-            )
-        )
         # Add a redirect from /nbclassic to /nbclassic/tree
         # if both notebook>=7 and nbclassic are installed.
         if len(nbclassic_path()) > 0:


### PR DESCRIPTION
This redirect causes an issue with the Jupytext extension, see https://github.com/mwouts/jupytext/issues/1051.

Because of the redirect, text notebooks are _downloaded_ in `nbclassic` , while the expected behavior would be to have them open as notebooks.

@jtpio do you think the redirect is still needed? I have made a quick test locally which seemed to suggest that it was not (I could click on the Edit button and get the text file open in the text editor - but that was with Jupytext installed).
