### PR TITLE
Copy marked.umd.js to marked.js and revert loading

### DIFF
--- a/nbclassic/static/base/js/markdown.js
+++ b/nbclassic/static/base/js/markdown.js
@@ -6,7 +6,7 @@ define([
     'base/js/utils',
     'base/js/mathjaxutils',
     'base/js/security',
-    'components/marked/lib/marked.umd',
+    'components/marked/lib/marked',
     'codemirror/lib/codemirror',
 ], function($, utils, mathjaxutils, security, marked, CodeMirror){
     "use strict";

--- a/nbclassic/static/base/js/namespace.js
+++ b/nbclassic/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "0.5.3";
+    Jupyter.version = "0.6.0.dev0";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/nbclassic/static/notebook/js/shortcuteditor.js
+++ b/nbclassic/static/notebook/js/shortcuteditor.js
@@ -5,7 +5,7 @@ define([
     "jquery",
     "notebook/js/quickhelp",
     "base/js/dialog",
-    "components/marked/lib/marked.umd"
+    "components/marked/lib/marked"
 ], function (
     $,
     QH,

--- a/nbclassic/static/tree/js/notebooklist.js
+++ b/nbclassic/static/tree/js/notebooklist.js
@@ -11,7 +11,7 @@ define([
     'base/js/keyboard',
     'moment',
     'bidi/bidi',
-    'components/marked/lib/marked.umd'
+    'components/marked/lib/marked'
 ], function($, IPython, utils, i18n, dialog, events, keyboard, moment, bidi, marked) {
     "use strict";
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -145,7 +145,7 @@ def find_package_data():
         pjoin(components, "jquery-ui", "dist", "jquery-ui.min.js"),
         pjoin(components, "jquery-ui", "dist", "themes", "smoothness", "jquery-ui.min.css"),
         pjoin(components, "jquery-ui",  "dist", "themes", "smoothness", "images", "*"),
-        pjoin(components, "marked", "lib", "marked.cjs"),
+        pjoin(components, "marked", "lib", "marked.js"),
         pjoin(components, "react", "react.production.min.js"),
         pjoin(components, "react", "react-dom.production.min.js"),
         pjoin(components, "requirejs", "require.js"),
@@ -417,8 +417,8 @@ class Bower(Command):
                 cwd=repo_root,
                 env=env
             )
-            # Copy the CommonJS files to their JavaScript equivalent to ensure correct loading.
-            shutil.copyfile(pjoin(self.bower_dir, "marked", "lib", "marked.cjs"), pjoin(self.bower_dir, "marked", "lib", "marked.js"))
+            # Copy the UMD files to their JavaScript equivalent to ensure correct loading.
+            shutil.copyfile(pjoin(self.bower_dir, "marked", "lib", "marked.umd.js"), pjoin(self.bower_dir, "marked", "lib", "marked.js"))
         except OSError as e:
             print("Failed to run bower: %s" % e, file=sys.stderr)
             print("You can install js dependencies with `npm install`", file=sys.stderr)

--- a/setupbase.py
+++ b/setupbase.py
@@ -418,7 +418,7 @@ class Bower(Command):
                 env=env
             )
             # Copy the CommonJS files to their JavaScript equivalent to ensure correct loading.
-            # shutil.copyfile(pjoin(self.bower_dir, "marked", "lib", "marked.cjs"), pjoin(self.bower_dir, "marked", "lib", "marked.js"))
+            shutil.copyfile(pjoin(self.bower_dir, "marked", "lib", "marked.cjs"), pjoin(self.bower_dir, "marked", "lib", "marked.js"))
         except OSError as e:
             print("Failed to run bower: %s" % e, file=sys.stderr)
             print("You can install js dependencies with `npm install`", file=sys.stderr)

--- a/setupbase.py
+++ b/setupbase.py
@@ -145,7 +145,7 @@ def find_package_data():
         pjoin(components, "jquery-ui", "dist", "jquery-ui.min.js"),
         pjoin(components, "jquery-ui", "dist", "themes", "smoothness", "jquery-ui.min.css"),
         pjoin(components, "jquery-ui",  "dist", "themes", "smoothness", "images", "*"),
-        pjoin(components, "marked", "lib", "marked.umd.js"),
+        pjoin(components, "marked", "lib", "marked.js"),
         pjoin(components, "react", "react.production.min.js"),
         pjoin(components, "react", "react-dom.production.min.js"),
         pjoin(components, "requirejs", "require.js"),
@@ -417,6 +417,8 @@ class Bower(Command):
                 cwd=repo_root,
                 env=env
             )
+            # Copy the CommonJS files to their JavaScript equivalent to ensure correct loading.
+            shutil.copyfile(pjoin(self.bower_dir, "marked", "lib", "marked.cjs"), pjoin(self.bower_dir, "marked", "lib", "marked.js"))
         except OSError as e:
             print("Failed to run bower: %s" % e, file=sys.stderr)
             print("You can install js dependencies with `npm install`", file=sys.stderr)

--- a/setupbase.py
+++ b/setupbase.py
@@ -145,7 +145,7 @@ def find_package_data():
         pjoin(components, "jquery-ui", "dist", "jquery-ui.min.js"),
         pjoin(components, "jquery-ui", "dist", "themes", "smoothness", "jquery-ui.min.css"),
         pjoin(components, "jquery-ui",  "dist", "themes", "smoothness", "images", "*"),
-        pjoin(components, "marked", "lib", "marked.js"),
+        pjoin(components, "marked", "lib", "marked.cjs"),
         pjoin(components, "react", "react.production.min.js"),
         pjoin(components, "react", "react-dom.production.min.js"),
         pjoin(components, "requirejs", "require.js"),
@@ -418,7 +418,7 @@ class Bower(Command):
                 env=env
             )
             # Copy the CommonJS files to their JavaScript equivalent to ensure correct loading.
-            shutil.copyfile(pjoin(self.bower_dir, "marked", "lib", "marked.cjs"), pjoin(self.bower_dir, "marked", "lib", "marked.js"))
+            # shutil.copyfile(pjoin(self.bower_dir, "marked", "lib", "marked.cjs"), pjoin(self.bower_dir, "marked", "lib", "marked.js"))
         except OSError as e:
             print("Failed to run bower: %s" % e, file=sys.stderr)
             print("You can install js dependencies with `npm install`", file=sys.stderr)


### PR DESCRIPTION
Fixes https://github.com/jupyter/nbclassic/issues/227

This revert the changes introduced in https://github.com/jupyter/nbclassic/pull/201. Instead of loading from `umd` file, we load from javascript as before, and we copy the `marked.umd.js` file to `marked.js` after bower has pulled the dependencies.

This also solves https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/pull/152