### PR TITLE
Add show_banner trait to control the banner display

### DIFF
--- a/docs/source/frontend_config.rst
+++ b/docs/source/frontend_config.rst
@@ -89,3 +89,12 @@ taking various value depending on the page where the configuration is issued.
 ``<section>`` can take various values like ``notebook``, ``tree``, and
 ``editor``. A ``common`` section contains configuration settings shared by all
 pages.
+
+
+Persisting configuration settings
+---------------------------------
+
+A banner might be shown to users to inform them about news or updates. This 
+banner can be hidden launching the server with the show_banner trait.::
+
+   jupyter notebook --NotebookApp.show_banner=False

--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -120,6 +120,13 @@ class NotebookApp(
 
     default_url = Unicode("%s/tree" % nbclassic_path()).tag(config=True)
 
+    show_banner = Bool(
+        True,
+        help="""Whether the banner is displayed on the page.
+        By default, the banner is displayed.
+        """
+        ).tag(config=True)
+
     # Override the default open_Browser trait in ExtensionApp,
     # setting it to True.
     open_browser = Bool(
@@ -184,6 +191,7 @@ class NotebookApp(
             base_dir, 'nbclassic/i18n'), fallback=True)
         self.jinja2_env.install_gettext_translations(nbui, newstyle=False)
         self.jinja2_env.globals.update(nbclassic_path=nbclassic_path)
+        self.jinja2_env.globals.update(show_banner=self.show_banner)
 
     def _link_jupyter_server_extension(self, serverapp):
         # Monkey-patch Jupyter Server's and nbclassic's static path list to include

--- a/nbclassic/static/base/js/namespace.js
+++ b/nbclassic/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "0.5.5";
+    Jupyter.version = "0.6.0.dev0";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/nbclassic/templates/page.html
+++ b/nbclassic/templates/page.html
@@ -138,6 +138,7 @@ dir="ltr">
 
 <div id="header" role="navigation" aria-label="{% trans %}Top Menu{% endtrans %}">
   <div  id="newsId" style="display: none">
+    {% if show_banner %}
     <div class="alert alert-info" role="alert">
       <div style="display: flex">
         <div>
@@ -155,6 +156,7 @@ dir="ltr">
         </div>
       </div>
     </div>
+    {% endif %}
   </div>
   <div id="header-container" class="container">
   <div id="ipython_notebook" class="nav navbar-brand"><a href="


### PR DESCRIPTION
Fixes https://github.com/jupyter/nbclassic/issues/242

Depends on https://github.com/jupyter/notebook_shim/pull/29 Once a new notebook_shim release is cut, we need o bump that dependency version in this PR.