### PR TITLE
State the correct name of the application in the desktop entry

### DIFF
--- a/jupyter-nbclassic.desktop
+++ b/jupyter-nbclassic.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
-Name=Jupyter Notebook
-Comment=Run Jupyter Notebook
+Name=Jupyter NbClassic
+Comment=Run Jupyter NbClassic
 Exec=jupyter-nbclassic %f
 Terminal=true
 Type=Application


### PR DESCRIPTION
In Fedora, we use the desktop file to generate the application entry in the graphical environment. Currently, both Notebook and NbClassic are propagated as "Jupyter Notebook" which is misleading. Changing the name and comment will make the displayed output easily recognizable.
cc @frenzymadness 