### PR TITLE
Update dependency requirements to minimum necessary

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,25 +28,10 @@ include_package_data = True
 packages = find:
 python_requires = >=3.7
 install_requires =
-    jinja2
-    tornado>=6.1
-    # pyzmq>=17 is not technically necessary,
-    # but hopefully avoids incompatibilities with Tornado 5. April 2018
-    pyzmq>=17
-    argon2-cffi
-    traitlets>=4.2.1
-    jupyter_core>=4.6.1
-    jupyter_client>=6.1.1
     ipython_genutils
-    jupyter_server>=1.8
-    nbformat
     notebook_shim>=0.2.3
-    nbconvert>=5
     nest-asyncio>=1.5
     ipykernel # bless IPython kernel for now
-    Send2Trash>=1.8.0
-    terminado>=0.8.3
-    prometheus_client
 
 [options.data_files]
 etc/jupyter/jupyter_server_config.d =


### PR DESCRIPTION
Addresses #252, removing the duplicate dependencies carried over by `notebook-shim`'s dependency on `jupyter-server`.