### PR TITLE
Add pyrsistent to build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
   "jupyter_packaging~=0.9,<2",
   "jupyter_server>=1.17.0",
+  "pyrsistent",
   "babel"
 ]
 build-backend = "jupyter_packaging.build_api"


### PR DESCRIPTION
When I tried an editable install, I got an error without pyrsistent.