### PR TITLE
fix: trust new notebooks and notebooks with new cells

### DIFF
--- a/nbclassic/tests/end_to_end/test_trust.py
+++ b/nbclassic/tests/end_to_end/test_trust.py
@@ -1,0 +1,30 @@
+from .utils import EDITOR_PAGE
+
+trust_test_code = """
+import IPython.display
+IPython.display.Javascript("window.javascriptExecuted = true")
+"""
+
+
+def test_trust(notebook_frontend):
+    def save_notebook():
+        notebook_frontend.evaluate("() => Jupyter.notebook.save_notebook()", page=EDITOR_PAGE)
+
+    # Add a cell that executes javascript
+    notebook_frontend.add_cell(index=0, content=trust_test_code)
+    notebook_frontend.execute_cell(0)
+    notebook_frontend.wait_for_cell_output(0)
+    # Make sure the JavaScript executed
+    assert notebook_frontend.evaluate("() => window.javascriptExecuted", page=EDITOR_PAGE) == True
+    # Check that we see the 'Trusted' text on the page
+    trusted = notebook_frontend.locate("#notification_trusted", page=EDITOR_PAGE)
+    assert trusted.get_inner_text() == "Trusted"
+    save_notebook()
+
+    # refresh the page, should be trusted
+    notebook_frontend.reload(EDITOR_PAGE)
+    notebook_frontend.wait_for_kernel_ready()
+    trusted = notebook_frontend.locate("#notification_trusted", page=EDITOR_PAGE)
+    assert trusted.get_inner_text() == "Trusted"
+    notebook_frontend.wait_for_cell_output(0)
+    assert notebook_frontend.evaluate("() => window.javascriptExecuted", page=EDITOR_PAGE) == True


### PR DESCRIPTION
# Problem
When a new notebook cell is created from the front end (this includes creating a new notebook), the notebook is not trusted after a page reload.   The core issue is that nbclassic creates an invalid notebook on the front end, which does not follow the nbformat 4.5 schema.

This problem only happens when Jupyter notebook 6.x/nbclassic is used in combination with nbformat >=5.1.0 (where nbformat schema 4.5 was introduced) or higher.
Before nbformat 5.1.0, there were no cell-ID's in the notebook format [JEP 62](https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md).
Starting from nbformat 5.1.0, Cell-ID's are added to notebook data https://github.com/jupyter/nbformat/pull/189. 


Following [JEP 62](https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md#proposed-enhancement), raw_cell, markdown and code_cell should include an id field. When it is not present, nbformat will add the id field to the cell to make it valid according to the schema.

However, this happens after the notebook is 'trusted'. I am not an expert on the notary system, but mutation of the notebook after it is marked trusted will basically turn the notebook into an untrusted notebook.

Therefore, if we want to make use of the notary system as intended, we should send valid notebooks from the front end to the back end. 

## Steps to reproduce


 * Install and run
 ```
 $ pip install "nbclassic<7" "nbformat>=5.1.0"
 $ jupyter nbclassic
 ```
 * Create a new notebook
 * Add this to a cell:
 ```python
 import IPython.display
 IPython.display.Javascript("window.javascriptExecuted = true")
 ```
 * Execute the cell
 * Save the notebook
 * Reload the notebook

Now, the notebook is seen as *not trusted*.

One could argue, this is not that bad, since it's a one time thing, but it is not: After trusting the notebook, add a new cell to the notebook, save, reload. The notebook is now *again* seen as untrusted.


## Expected behavior

A new notebook and a notebook after a cell is added should be trusted after a reload.


## Related issues / PRs

 * https://github.com/jupyter/notebook/issues/6828 This behaviour is also seen in notebook v7 (I did not validate this)
 * https://github.com/jupyter/nbformat/issues/359
 * https://github.com/jupyter/notebook/pull/5928


# Solution

We should send valid notebooks from the front end to the back end. This means adding the id field to the raw_cell, markdown, and code_cell when they are created.

This PR is modeled after https://github.com/jupyterlab/jupyterlab/pull/10018. Although the id field should only be set for the raw_cell, markdown and code_cell, the JupyterLab PR sets the id field for all cell types, we only do this for the raw_cell, markdown and code_cell as per the JEP 62.

As explained in the code, we use a uuid trimmed to 8 characters, [like nbformat](https://github.com/jupyter/nbformat/blob/60b6151fedcbdc9f137fb2d223eeb10c935a8378/nbformat/corpus/words.py).
