### PR TITLE
fix: pasting outside of cells doing nothing

### DIFF
--- a/nbclassic/static/notebook/js/clipboard.js
+++ b/nbclassic/static/notebook/js/clipboard.js
@@ -74,8 +74,8 @@ function paste(event) {
         }
     }
     first_inserted.focus_cell();
+    event.preventDefault();
   }
-  event.preventDefault();
 }
 
 function notebookOnlyEvent(callback) {


### PR DESCRIPTION
Previously pasting anything but cells into the notebook would do nothing. This way pasting other content uses the browser's default action.

Fixes #284
Fixes https://github.com/widgetti/solara/issues/671