### PR TITLE
Fix SyntaxWarning from update message

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -325,7 +325,7 @@ class NotebookApp(
         router.add_rules(core_rules)
         router.add_rules(static_handlers)
         router.add_rules(final_rules)
-        print("""
+        print(r"""
   _   _          _      _
  | | | |_ __  __| |__ _| |_ ___
  | |_| | '_ \/ _` / _` |  _/ -_)


### PR DESCRIPTION
The use of backslashes in the ASCII-art "Update" banner results in an "invalid escape sequence" SyntaxWarning under Python 3.12. Fix by changing the banner string to a raw string (which ignores backslashes).

Fixes #296