### PR TITLE
Remove use of deprecated distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ Python {py} detected.
 
 # At least we're on the python version we need, move on.
 
-# BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
+# BEFORE importing setuptools, remove MANIFEST. Setuptools doesn't properly
 # update it when the contents of directories change.
 if os.path.exists('MANIFEST'): os.remove('MANIFEST')
 
@@ -50,7 +50,6 @@ from setuptools import setup
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 from setupbase import (
-    version,
     find_packages,
     find_package_data,
     check_package_data_first,
@@ -68,9 +67,9 @@ setup_args = dict(
     package_data    = find_package_data(),
 )
 
-# Custom distutils/setuptools commands ----------
-from distutils.command.build_py import build_py
-from distutils.command.sdist import sdist
+# Custom setuptools commands ---------------------
+from setuptools.command.build_py import build_py
+from setuptools.command.sdist import sdist
 from setuptools.command.bdist_egg import bdist_egg
 from setuptools.command.develop import develop
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -10,14 +10,14 @@ This includes:
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import logging
 import os
 import re
 import shlex
 import shutil
 import sys
 
-from distutils import log
-from distutils.cmd import Command
+from setuptools import Command
 from fnmatch import fnmatch
 from glob import glob
 from multiprocessing.pool import ThreadPool
@@ -28,6 +28,8 @@ if sys.platform == 'win32':
 else:
     def list2cmdline(cmd_list):
         return ' '.join(map(shlex.quote, cmd_list))
+
+log = logging.getLogger(__name__)
 
 #-------------------------------------------------------------------------------
 # Useful globals and utility functions


### PR DESCRIPTION
This PR fixes a portion of #307, by removing distutils which was removed in Python 3.13. The replacements used include:

- Setuptools for command execution
- logging for log

I also ran through the following manual tests:
- Install locally using `pip install .`
- Install editable using `pip install -e .`
- Install test and docs groups
- `python setup.py sdist`
- `python setup.py bdist_wheel`

I also ran the automated test suite, but I don't think those cover the setup.py. Please let me know if there is anything else I should test or check. Thanks!