### PR TITLE
Fix documentation title formatting

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@
 
 import sys
 import os
-import shlex
 import shutil
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -117,7 +116,7 @@ release = version_ns['__version__']
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -198,10 +198,10 @@ html_context = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = "Classic Jupyter Notebook"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+html_short_title = "NbClassic"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,6 @@
-==================
+=================
 Jupyter NbClassic
-==================
+=================
 
 :ref:`Getting Started <NbClassicUsage>`
 

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -1,3 +1,5 @@
+.. _server_security:
+
 Security in the Jupyter NbClassic server
 ========================================
 


### PR DESCRIPTION
Closes #313 by setting an explicit `html_title`.

<img width="1108" alt="image" src="https://github.com/user-attachments/assets/b42c0b2b-9f2e-4745-b740-2c982ab306b6" />
