### PR TITLE
Improve JS Test Docs for macOS and Fix Flaky Test

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -195,6 +195,10 @@ or to run just ``nbclassic/tests/notebook/deletecell.js``::
 
     python -m nbclassic.jstest notebook/deletecell.js
 
+.. note::
+   If you are getting spawn errors with an ARM Mac on macOS, make sure you
+   have Rosetta installed.
+
 
 Building the Documentation
 --------------------------

--- a/nbclassic/tests/notebook/attachments.js
+++ b/nbclassic/tests/notebook/attachments.js
@@ -42,6 +42,15 @@ casper.notebook_test(function () {
 
     // Validate and render the markdown cell
     this.thenClick('#btn_ok');
+
+    // Wait for cell content to update before rendering
+    this.waitFor(function() {
+        return this.evaluate(function() {
+            var cell = Jupyter.notebook.get_cell(0);
+            return cell.get_text().indexOf('![') >= 0;
+        });
+    });
+
     this.thenEvaluate(function() {
         Jupyter.notebook.get_cell(0).render();
     });


### PR DESCRIPTION
The JS test suite wasn't running for me. This PR adds a note to make sure you have Rosetta installed in order to spawn caspterjs for the tests. It also adds a waitFor to one of the tests to fix a test failure I was getting locally.