### PR TITLE
Fix CI `Check Release` job with deprecated action use

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -54,4 +54,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Link Check
         if: ${{ matrix.group == 'link_check' }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-links@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1


### PR DESCRIPTION
check-links moved to maintainer-tools