### PR TITLE
Drop support for Python 3.8, Test with 3.12 and 3.13

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.12"
           architecture: "x64"
       - name: Get pip cache dir
         id: pip-cache

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  python-version: '3.12'
+  python-version: '3.11'
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,10 @@ jobs:
       run: |
         pip install -e .[test] codecov
         pip install -r docs/doc-requirements.txt
-        wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
+    - name: Install pandoc
+      uses: pandoc/actions/setup@v1.1.0
+      with:
+        version: 3.6.4
     - name: List installed packages
       run: |
         pip freeze

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,21 +9,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  python-version: '3.12'
+
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-22.04]
-        python-version: [ '3.12' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Install Python ${{ matrix.python-version }}
+    - name: Install Python ${{ env.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ env.python-version }}
         architecture: 'x64'
     - name: Upgrade packaging dependencies
       run: |
@@ -36,9 +36,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+        key: ${{ runner.os }}-pip-${{ env.python-version }}-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-${{ env.python-version }}-
           ${{ runner.os }}-pip-
     - name: Install the Python dependencies
       run: |

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  python-version: '3.12'
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -26,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: ${{ env.python-version }}
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -50,9 +53,9 @@ jobs:
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-pip-${{ env.python-version }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python }}
+            ${{ runner.os }}-pip-${{ env.python-version }}
 
       - name: Temporary workaround for sanitizer loading in JS Tests
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13, windows-2022]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13, windows-2022]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13, windows-2022]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/nbclassic/tests/end_to_end/test_save_readonly_as.py
+++ b/nbclassic/tests/end_to_end/test_save_readonly_as.py
@@ -23,9 +23,6 @@ def set_notebook_name(nb, name):
     JS = f'() => Jupyter.notebook.rename("{name}")'
     nb.evaluate(JS, page=EDITOR_PAGE)
 
-# on Python 3.7 we get an old playwright which hangs on body.press("Escape")
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher due to playwright")
-# and we also see this fail on osx randomly
 @pytest.mark.skipif(sys.platform == 'darwin', reason="fails randomly on osx")
 def test_save_readonly_as(notebook_frontend):
     print('[Test] [test_save_readonly_as]')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ license.file = "LICENSE"
 authors = [
   { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
@@ -34,7 +34,6 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This PR:

- Drops support for Python 3.8 since it has been EOL for about 5 months
- Adds tests for Python 3.12 and 3.13