### PR TITLE
Remove obsolete setuptools requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires = [
   "babel",
   "hatchling",
   "jupyter-server>=1.17",
-  "setuptools",
 ]
 
 [project]


### PR DESCRIPTION
The PEP517 backend uses Hatchling only, and setuptools is not used anywhere.