### PR TITLE
Support offline source distribution builds

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-linkcheck-
       - name: Upgrade packaging dependencies
         run: |
-          pip install --upgrade pip setuptools wheel --user
+          pip install --upgrade pip wheel --user
       - name: Install Dependencies
         run: |
           pip install -e .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         architecture: 'x64'
     - name: Upgrade packaging dependencies
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade pip wheel
     - name: Get pip cache dir
       id: pip-cache
       run: |

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install --upgrade setuptools wheel
           npm run build
           npm install -g casperjs@1.1.4 phantomjs-prebuilt@2.1.16
           pip install .[test]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -133,3 +133,24 @@ jobs:
         run: |
           cd sdist/test
           pytest -vv || pytest -vv --lf
+  test_offline_build:
+    runs-on: ubuntu-latest
+    needs: [make_sdist]
+    name: Test building offline
+    timeout-minutes: 20
+    steps:
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+      - name: Install From SDist
+        run: |
+          set -ex
+          cd sdist
+          mkdir test
+          tar --strip-components=1 -zxvf *.tar.gz -C ./test
+      - name: Test offline build with unshare
+        run: |
+          # Use unshare to create a network namespace that blocks network access
+          cd test
+          sudo unshare --net bash -c "python -m build --no-isolation --wheel"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -153,4 +153,6 @@ jobs:
         run: |
           # Use unshare to create a network namespace that blocks network access
           cd sdist/test
-          sudo unshare --net bash -c "python -m build --no-isolation --wheel"
+          python -m venv .venv
+          .venv/bin/python -m pip install build babel jupyter-server hatch-jupyter-builder
+          sudo unshare --net bash -c ".venv/bin/python -m build --no-isolation --wheel"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -152,5 +152,5 @@ jobs:
       - name: Test offline build with unshare
         run: |
           # Use unshare to create a network namespace that blocks network access
-          cd test
+          cd sdist/test
           sudo unshare --net bash -c "python -m build --no-isolation --wheel"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ Installing the Jupyter NbClassic
 Once you have installed the dependencies mentioned above, use the following
 steps::
 
-    pip install --upgrade setuptools pip
+    pip install --upgrade pip
     git clone https://github.com/jupyter/nbclassic
     cd nbclassic
     pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires = [
   "babel",
   "hatchling",
   "jupyter-server>=1.17",
-  "setuptools",
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,11 @@ dependencies = [
   "hatch-jupyter-builder>=0.9.1",
 ]
 build-function = "hatch_jupyter_builder.npm_builder"
+# Allow offline builds of sdist, prevents running yarn install again
+skip-if-exists = ["nbclassic/static/components/MathJax/MathJax.js"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = ["yarn"]
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"

--- a/tools/install_pydeps.py
+++ b/tools/install_pydeps.py
@@ -29,7 +29,7 @@ def attempt(arg_list, max_attempts=1, name=''):
 
 def run():
     steps = {
-        'step1': """python -m pip install -U pip setuptools wheel""".split(' '),
+        'step1': """python -m pip install -U pip""".split(' '),
         'step2': """pip install pytest-playwright""".split(' '),
         'step3': """playwright install""".split(' '),
         'step4': """pip install .[test]""".split(' '),


### PR DESCRIPTION
Fixes #335.

Even though the sdist contains the built distribution including node_modules, running `python -m build` was causing yarn to try to redownload dependencies.

This fix looks to see if one of the files in `nbclassic/static/components` exists, and if so, it skips rebuilding.

Another option is to configure build and source directories, but this would require users who checkout from Git to explicitly run `yarn` prior to `pip install .`, since the build would always get skipped if the source directory is missing.

I also added a CI step to test that this is working.