### PR TITLE
Fix mo translations missing from wheels

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          npm run build
           npm install -g casperjs@1.1.4 phantomjs-prebuilt@2.1.16
           pip install .[test]
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,10 +33,6 @@ jobs:
       with:
         node-version: '16.x'
 
-    - name: Install and build JS
-      run: |
-        npm run build
-
     - name: Install Python dependencies
       run: |
         python tools/install_pydeps.py

--- a/nbclassic/i18n/README.md
+++ b/nbclassic/i18n/README.md
@@ -1,70 +1,73 @@
 # Implementation Notes for Internationalization of Jupyter Notebook
 
-The implementation of i18n features for jupyter notebook is still a work-in-progress:
+The implementation of i18n features for jupyter notebook:
 
 - User interface strings are (mostly) handled
 - Console messages are not handled (their usefulness in a translated environment is questionable)
-- Tooling has to be refined
+- Tooling has been updated to use Hatch build system
 
-However…
-
-## How the language is selected ?
+## How the language is selected?
 
 1. `jupyter notebook` command reads the `LANG` environment variable at startup,
-(`xx_XX` or just `xx` form, where `xx` is the language code you're wanting to
-run in).
+   (`xx_XX` or just `xx` form, where `xx` is the language code you're wanting to
+   run in).
 
 Hint: if running Windows, you can set it in PowerShell with `${Env:LANG} = "xx_XX"`.
-      if running Ubuntu 14, you should set environment variable `LANGUAGE="xx_XX"`.
+if running Ubuntu, you should set environment variable `LANGUAGE="xx_XX"`.
 
 2. The preferred language for web pages in your browser settings (`xx`) is
    also used. At the moment, it has to be first in the list.
 
 ## Contributing and managing translations
 
-Finding and translating the `.pot` files could be (partially) done with a translation API, see the repo [Jupyter Notebook Azure Translator](https://github.com/berendjan/Jupyter-Notebook-Azure-Translator.git) for a possible starting point. (Not affiliated with Jupyter)
-
 ### Requirements
 
 - *pybabel* (could be installed `pip install babel`)
 - *po2json* (could be installed with `npm install -g po2json`)
+- *hatch* (could be installed with `pip install hatch`)
 
-**All i18n-related commands are done from the related directory :**
-
-    cd notebook/i18n/
+**All i18n-related commands are done from the project root directory.**
 
 ### Message extraction
 
 The translatable material for notebook is split into 3 `.pot` files, as follows:
 
-- *notebook/i18n/notebook.pot* - Console and startup messages, basically anything that is
-	produced by Python code.
-- *notebook/i18n/nbui.pot* - User interface strings, as extracted from the Jinja2 templates
-	in *notebook/templates/\*.html*
-- *noteook/i18n/nbjs.pot* - JavaScript strings and dialogs, which contain much of the visible
-	user interface for Jupyter notebook.
+- *nbclassic/i18n/notebook.pot* - Console and startup messages
+- *nbclassic/i18n/nbui.pot* - User interface strings from Jinja2 templates
+- *nbclassic/i18n/nbjs.pot* - JavaScript strings and dialogs
 
 To extract the messages from the source code whenever new material is added, use the
 `pybabel` command:
 
 ```shell
-pybabel extract -F babel_notebook.cfg -o notebook.pot --no-wrap --project Jupyter .
-pybabel extract -F babel_nbui.cfg -o nbui.pot --no-wrap --project Jupyter .
-pybabel extract -F babel_nbjs.cfg -o nbjs.pot --no-wrap --project Jupyter .
-```
+pybabel extract -F nbclassic/i18n/babel_notebook.cfg -o nbclassic/i18n/notebook.pot --no-wrap --project Jupyter .
+pybabel extract -F nbclassic/i18n/babel_nbui.cfg -o nbclassic/i18n/nbui.pot --no-wrap --project Jupyter .
+pybabel extract -F nbclassic/i18n/babel_nbjs.cfg -o nbclassic/i18n/nbjs.pot --no-wrap --project Jupyter .
 
 After this is complete you have 3 `.pot` files that you can give to a translator for your favorite language.
 
-Finding and translating the `.pot` files could be (partially done with a translation API, see the repo [Jupyter Notebook Azure Translator](https://github.com/berendjan/Jupyter-Notebook-Azure-Translator.git) for a possible starting point. (Not affiliated with Jupyter)
-
 ### Messages compilation
 
-After the source material has been translated, you should have 3 `.po` files with the same base names
-as the `.pot` files above.  Put them in `notebook/i18n/${LANG}/LC_MESSAGES`, where `${LANG}` is the language
-code for your desired language ( i.e. German = "de", Japanese = "ja", etc. ).
+After the source material has been translated, you should have 3 .po files with the same base names
+as the `.pot` files above. Put them in `nbclassic/i18n/${LANG}/LC_MESSAGES`, where `${LANG}` is the language
+code for your desired language (i.e. German = "de", Japanese = "ja", etc.).
 
-*notebook.po* and *nbui.po* need to be converted from `.po` to `.mo` format for
-use at runtime.
+### Compiling with Hatch
+
+The `.po` to `.mo` conversion is now handled automatically by a Hatch build hook.
+When building the package with Hatch, the `.po` files are automatically compiled to
+`.mo` files.
+
+To manually compile the translation files without building the package, run:
+
+```shell
+hatch run compile-translations
+```
+
+### Manual Compilation (if needed)
+
+If you need to manually compile the translation files:
+`notebook.po` and `nbui.po` need to be converted from .po to .mo format:
 
 ```shell
 pybabel compile -D notebook -f -l ${LANG} -i ${LANG}/LC_MESSAGES/nbclassic.po -o ${LANG}/LC_MESSAGES/nbclassic.mo
@@ -122,13 +125,5 @@ of languages in the UI ( never a good thing ).
 2. We will need to decide if console messages should be translatable, and enable them if desired.
 3. The keyboard shortcut editor was implemented after the i18n work was completed, so that portion
 does not have translation support at this time.
-4. Babel's documentation has instructions on how to integrate messages extraction
-into your *setup.py* so that eventually we can just do:
-
-    ./setup.py extract_messages
 
 I hope to get this working at some point in the near future.
-5. The conversions from `.po` to `.mo` probably can and should be done using `setup.py install`.
-
-
-Any questions or comments please let me know @JCEmmons on github (emmo@us.ibm.com)

--- a/nbclassic/i18n/build_py_translations.py
+++ b/nbclassic/i18n/build_py_translations.py
@@ -1,0 +1,56 @@
+"""Hatch build hook to compile Portable Object (.po) translations to .mo."""
+
+from pathlib import Path
+import subprocess
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from hatchling.plugin import hookimpl
+
+
+def compile_translations() -> None:
+    """Compile the .po files into .mo files that contain the translations."""
+    i18n_dir = Path(__file__).parent.absolute()
+
+    paths = list(i18n_dir.glob('*/LC_MESSAGES'))
+
+    for p in paths:
+        LANG = p.parent.name
+
+        for component in ['nbclassic', 'nbui']:
+            po_file = p / f'{component}.po'
+            mo_file = p / f'{component}.mo'
+
+            if not po_file.exists():
+                print(f"Warning: {po_file} does not exist, skipping.")
+                continue
+
+            cmd = [
+                'pybabel', 'compile',
+                '-D', component,
+                '-f',
+                '-l', LANG,
+                '-i', str(po_file),
+                '-o', str(mo_file)
+            ]
+
+            try:
+                subprocess.run(cmd, check=True)
+                print(f"Compiled: {po_file} -> {mo_file}")
+            except subprocess.CalledProcessError as e:
+                print(f"Error compiling {po_file}: {e}")
+
+
+class CompileTranslationsHook(BuildHookInterface):
+    """Build hook for compiling translation files."""
+
+    def finalize(self, *args) -> None:
+        """Finalize the build hook - compile translation files."""
+        compile_translations()
+
+
+@hookimpl
+def hatch_register_build_hook():
+    return CompileTranslationsHook
+
+if __name__ == "__main__":
+    compile_translations()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,14 @@ scripts.jupyter-nbclassic-extension = "nbclassic.nbextensions:main"
 scripts.jupyter-nbclassic-serverextension = "nbclassic.serverextensions:main"
 
 [tool.hatch.build]
+ensured-targets = [
+  "nbclassic/i18n/fr_FR/LC_MESSAGES/nbjs.json",
+  "nbclassic/static/base/js/events.js",
+  "nbclassic/static/style/style.min.css",
+  "nbclassic/static/auth/js/main.min.js",
+  "nbclassic/static/components/MathJax/MathJax.js",
+]
 artifacts = [
-  "nbclassic/i18n/*/LC_MESSAGES/*.mo",
   "nbclassic/i18n/*/LC_MESSAGES/nbjs.json",
   "nbclassic/static/style/*.min.css*",
   "nbclassic/static/*/js/built/",
@@ -148,8 +154,17 @@ artifacts = [
 "nbclassic/static/components/xterm.js/index.js" = "nbclassic/static/components/xterm.js/index.js"
 
 [tool.hatch.build.targets.sdist]
+ensured-targets = [
+  "nbclassic/i18n/fr_FR/LC_MESSAGES/nbjs.po",
+  "nbclassic/i18n/fr_FR/LC_MESSAGES/nbclassic.po",
+]
 exclude = [
   ".github",
+]
+
+[tool.hatch.build.targets.wheel]
+ensured-targets = [
+  "nbclassic/i18n/fr_FR/LC_MESSAGES/nbclassic.mo",
 ]
 
 [tool.hatch.build.targets.wheel.shared-data]
@@ -167,6 +182,21 @@ skip-if-exists = [ "nbclassic/static/components/MathJax/MathJax.js" ]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 npm = [ "yarn" ]
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "nbclassic/i18n/build_py_translations.py"
+
+[tool.hatch.envs.default.scripts]
+compile-translations = "hatch -e compile run translations"
+
+[tool.hatch.envs.compile]
+dependencies = [
+  "hatchling",
+  "babel",
+]
+
+[tool.hatch.envs.compile.scripts]
+translations = "python -m nbclassic.i18n.build_py_translations"
 
 [tool.check-wheel-contents]
 ignore = [


### PR DESCRIPTION
Fixes #338. When we were using setuptools, the `setupbase.py` had a script to compile the translations that I missed during the translation to using hatch for the build backend.

- Adds a hatch custom build script to compile the po files to mo files during the build process
- Updates the i18n README for how to run the script with hatch