### PR TITLE
Add CI workflow dispatch and timeouts

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   check_release:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         group: [check_release, link_check]

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -4,6 +4,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["*"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
     branches: '*'
   pull_request:
     branches: '*'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -5,6 +5,7 @@ on:
     branches: "*"
   pull_request:
     branches: "*"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   enforce-label:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: enforce-triage-label
         uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -5,6 +5,7 @@ on:
     branches: '*'
   pull_request:
     branches: '*'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR adds additional Workflow Dispatch and test timeouts to allow us to manually execute tests and ensure if one gets stuck that it times out in a reasonable amount of time.