### PR TITLE
Improve GitHub Action security

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -23,9 +23,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
           architecture: "x64"
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Cache checked links
         if: ${{ matrix.group == 'link_check' }}
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/pytest-link-check
           key: ${{ runner.os }}-linkcheck-${{ hashFiles('**/*.md', '**/*.rst') }}-md-links
@@ -57,19 +57,19 @@ jobs:
           pip install -e .
       - name: Check Release
         if: ${{ matrix.group == 'check_release' }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@45ee32c387085d5f1df41da443ade8b952a9dac6 # v2
         with:
           version_spec: 100.100.100
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Link Check
         if: ${{ matrix.group == 'link_check' }}
-        uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/check-links@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
         with:
           ignore_glob: nbclassic/static/components/**/*.md docs-translations/*/*.md
           ignore_links: "http://127.0.0.1 https://stackoverflow https://github.com"
       - name: Upload Assets
         if: ${{ matrix.group == 'check_release' && github.event_name == 'push' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: nbclassic-jupyter-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,9 +21,9 @@ jobs:
       fail-fast: false
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Install Python ${{ env.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ env.python-version }}
         architecture: 'x64'
@@ -35,7 +35,7 @@ jobs:
       run: |
         echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
     - name: Cache pip
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ env.python-version }}-${{ hashFiles('pyproject.toml') }}
@@ -47,7 +47,7 @@ jobs:
         pip install -e .[test] codecov
         pip install -r docs/doc-requirements.txt
     - name: Install pandoc
-      uses: pandoc/actions/setup@v1.1.0
+      uses: pandoc/actions/setup@54978b2465cef52a89f0e50a71d1397b1c25b469 # v1.1.0
       with:
         version: 3.6.4
     - name: List installed packages

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
 
       - name: Test jupyterlab
-        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
         with:
           package_name: jupyterlab
           package_spec: "\".[test]\""

--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -9,4 +9,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: enforce-triage-label
-        uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -14,6 +14,9 @@ concurrency:
 env:
   python-version: '3.12'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -27,13 +27,13 @@ jobs:
           - group: services
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.python-version }}
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '16.x'
 
@@ -42,7 +42,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache yarn
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Cache pip on Linux
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
@@ -60,7 +60,7 @@ jobs:
             ${{ runner.os }}-pip-${{ env.python-version }}
 
       - name: Cache pip on macOS
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: startsWith(runner.os, 'macOS')
         with:
           path: ~/Library/Caches/pip

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,15 +22,15 @@ jobs:
         python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '16.x'
 

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -23,6 +23,9 @@ on:
         description: "Use PRs with activity since the last stable git tag"
         required: false
         type: boolean
+permissions:
+  contents: read
+
 jobs:
   prep_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -29,11 +29,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
 
       - name: Prep Release
         id: prep-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@45ee32c387085d5f1df41da443ade8b952a9dac6 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -24,7 +24,7 @@ jobs:
 
       - name: Publish changelog
         id: publish-changelog
-        uses: jupyter-server/jupyter_releaser/.github/actions/publish-changelog@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/publish-changelog@45ee32c387085d5f1df41da443ade8b952a9dac6 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,6 +12,9 @@ on:
         description: "Comma separated list of steps to skip"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   publish_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,9 +19,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Populate Release
         id: populate-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@45ee32c387085d5f1df41da443ade8b952a9dac6 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}
@@ -40,7 +40,7 @@ jobs:
         id: finalize-release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@45ee32c387085d5f1df41da443ade8b952a9dac6 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           release_url: ${{ steps.populate-release.outputs.release_url }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: '3.13'
       - name: Lint with Pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   build:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -32,9 +32,9 @@ jobs:
         python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
       - name: Install pip dependencies
         run: |
           pip install -v -e ".[test]" pytest-cov
@@ -64,9 +64,9 @@ jobs:
 #    timeout-minutes: 20
 #    runs-on: ubuntu-latest
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 #      - name: Base Setup
-#        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+#        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
 #        with:
 #          python_version: "3.8"
 #      - name: Install minimum versions
@@ -80,9 +80,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
       - name: Install the Python dependencies
         run: |
           pip install --pre -e ".[test]"
@@ -99,14 +99,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
       - name: Build SDist
         run: |
           pip install build
           python -m build --sdist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "sdist"
           path: dist/*.tar.gz
@@ -118,9 +118,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
       - name: Download sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       - name: Install From SDist
         run: |
           set -ex
@@ -141,9 +141,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@d5b08e36724fe4271b4751cc0d84c80c2e5c982c # v1
       - name: Download sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       - name: Install From SDist
         run: |
           set -ex


### PR DESCRIPTION
This PR implements two [best practices](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions?learn=getting_started):

1. Pin GitHub Actions to their full commit SHA version
2. Reduce `GITHUB_TOKEN` scope to repository read by default. Permissions can then be increased only when needed.