### PR TITLE
Fix double URL encoding error when creating a notebook in a folder containing spaces

### DIFF
--- a/nbclassic/static/tree/js/newnotebook.js
+++ b/nbclassic/static/tree/js/newnotebook.js
@@ -81,7 +81,7 @@ define([
         var that = this;
         kernel_name = kernel_name || this.default_kernel;
         var w = window.open(undefined, IPython._target);
-        var dir_path = $('body').attr('data-notebook-path');
+        var dir_path = utils.get_body_data('notebookPath');
         this.contents.new_untitled(dir_path, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/5841

Steps to reproduce:

- Run `jupyter nbclassic`
- Create a new folder with a space in the name
- Open the folder
- Refresh the page (`<body>`'s `data-notebook-path` should now be url-encoded)
- Create a new python3 notebook
- Get the error from the linked issue

The fix is to use the existing util `get_body_data` to first decode the notebook path since `Contents.prototype.api_url` will encode it again.