### PR TITLE
chore(deps): bump underscore from 1.13.7 to 1.13.8 to address CVE-2026-27601

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "requirejs-plugins": "~1.0.2",
     "requirejs-text": "~2.0.16",
     "text-encoding": "~0.1",
-    "underscore": "~1.13.7"
+    "underscore": "~1.13.8"
   },
   "engines": {
     "yarn": "^1.22.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3279,10 +3279,10 @@ ua-parser-js@^0.7.30:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.40.tgz#c87d83b7bb25822ecfa6397a0da5903934ea1562"
   integrity sha512-us1E3K+3jJppDBa3Tl0L3MOJiGhe1C6P0+nIvQAFYbxlMAx0h81eOwLmU57xgqToduDDPx3y5QsdjPfDu+FgOQ==
 
-underscore@>=1.8.3, underscore@~1.13.7:
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.7.tgz#970e33963af9a7dda228f17ebe8399e5fbe63a10"
-  integrity sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==
+underscore@>=1.8.3, underscore@~1.13.8:
+  version "1.13.8"
+  resolved "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz#a93a21186c049dbf0e847496dba72b7bd8c1e92b"
+  integrity sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==
 
 undici-types@~6.20.0:
   version "6.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,7 +3281,7 @@ ua-parser-js@^0.7.30:
 
 underscore@>=1.8.3, underscore@~1.13.8:
   version "1.13.8"
-  resolved "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz#a93a21186c049dbf0e847496dba72b7bd8c1e92b"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.8.tgz#a93a21186c049dbf0e847496dba72b7bd8c1e92b"
   integrity sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==
 
 undici-types@~6.20.0:


### PR DESCRIPTION
## Summary
Updates underscore dependency from 1.13.7 to 1.13.8 to address security vulnerability CVE-2026-27601.

## Changes
Bump underscore from ~1.13.7 to ~1.13.8 in package.json.

## Security
Fixes CVE-2026-27601.